### PR TITLE
Edit GlobalStyle to fix feather icons position

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,21 +8,31 @@ import reset from 'styled-reset'
 import { createGlobalStyle } from 'styled-components'
 
 const GlobalStyle = createGlobalStyle`
-    ${reset}
+${reset}
 
-    html {
-        height: 100vh;
-        width: 100vw;
-    }
-    
-    #root {
-        background-color: #FEFDFC;
-        height: 100%;
-    }
+html {
+    height: 100vh;
+    width: 100vw;
+}
 
-    body, textarea {
-        font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif !important;
-    }
+#root {
+    background-color: #FEFDFC;
+    height: 100%;
+}
+
+body, textarea {
+    font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif !important;
+}
+
+.feather {
+    position: relative;
+    top: .13em;
+    width: 1em;
+    height: 1em;
+    margin-right: .5em;
+    display: inline-block;
+    vertical-align: auto;
+}
 `
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
CSS 스타일 없으니까 `FeatherIcon`이 옆 텍스트랑 높이가 안 맞는 문제 

<img width="259" alt="Screenshot 2024-02-13 at 16 31 24" src="https://github.com/GooseMoment/Peak/assets/20675630/8b412999-2dc8-4e2c-a41d-571187daa665">

그래서 `main.jsx` 속 `GlobalStyle`에 스타일 추가함.
<img width="197" alt="Screenshot 2024-02-13 at 16 34 08" src="https://github.com/GooseMoment/Peak/assets/20675630/f8ff7744-d253-43ca-8fbb-012ee11383b2">

참고: 스크린샷 속 사이드바 모습은 이 PR에 없음. `layout/sidebar` 브랜치에서 작업 중 