### PR TITLE
ErrorPage 추가 및 Layout 개정

### DIFF
--- a/frontend/src/containers/Layout.jsx
+++ b/frontend/src/containers/Layout.jsx
@@ -1,18 +1,16 @@
 import { useState } from "react"
-import { Outlet } from "react-router-dom"
 
 import Sidebar from "@components/common/Sidebar"
 
 import styled from "styled-components"
 
-const RootLayout = ({noSidebar, children}) => {
+const Layout = ({noSidebar, children}) => {
     let [hideSidebar, setHideSidebar] = useState(false)
     
     return (
     <App>
         { noSidebar ? null : <Sidebar hide={hideSidebar} setHide={setHideSidebar} />}
         <Content $hideSidebar={hideSidebar}>
-            <Outlet />
             {children}
         </Content>
     </App>
@@ -36,4 +34,4 @@ transition-timing-function: cubic-bezier(.86,0,.07,1);
 
 // Reference: https://every-layout.dev/layouts/sidebar
 
-export default RootLayout
+export default Layout

--- a/frontend/src/pages/ErrorPage.jsx
+++ b/frontend/src/pages/ErrorPage.jsx
@@ -1,15 +1,15 @@
 import { Link, useRouteError } from "react-router-dom"
 
-import RootLayout from "@/containers/RootLayout"
+import Layout from "@/containers/Layout"
 
 const ErrorPage = () => {
     const error = useRouteError();
 
-    return <RootLayout noSidebar={true}>
+    return <Layout noSidebar={true}>
         <h1>{error.status}: {error.statusText}</h1>
         <p>To GooseMoment Dev, if you encouter this error, please check <code>@/router.jsx</code>.</p>
         <Link to="/">Go to index</Link>
-    </RootLayout>
+    </Layout>
 }
 
 export default ErrorPage

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -3,13 +3,15 @@ import {
     createBrowserRouter
 } from "react-router-dom"
 
-import RootLayout from "@containers/RootLayout"
+import Layout from "@containers/Layout"
 import ErrorPage from "@pages/ErrorPage"
 
 const router = createBrowserRouter([
     {
         path: "/",
-        element: <RootLayout />,
+        element: <Layout>
+            <Outlet />
+        </Layout>,
         errorElement: <ErrorPage />,
         children: [
             {


### PR DESCRIPTION
## Errorpage 추가
![Screenshot 2024-02-13 at 23 35 22](https://github.com/GooseMoment/Peak/assets/20675630/7cbb8dac-bcf5-4226-b57e-e87085a427ac)

router 관련 에러라면(대부분 404) 모두 처리하는 에러 페이지를 추가. (`@pages/ErrorPage.jsx`)

## Layout 개정
사이드바를 라우팅에서 제외하기 위해서 [`<Outlet/>`](https://reactrouter.com/en/main/components/outlet)을 추가하느라 `Layout.jsx`를 `RootLayout.jsx`로 사용의 범위를 좁혔었는데(47f51b2), `@/router.jsx`에서 직접 children으로 `<Outlet />`을 전달해도 됨을 발견.
`RootLayout.jsx`의 `<Outlet />`을 제거, `{children}`만 유지, 그리고 파일 이름 원상복구 `RootLayout` -> `Layout`