### PR TITLE
Add console.log(error) in ErrorPage.jsx

### DIFF
--- a/frontend/src/pages/ErrorPage.jsx
+++ b/frontend/src/pages/ErrorPage.jsx
@@ -1,15 +1,24 @@
-import { Link, useRouteError } from "react-router-dom"
+import { Link, isRouteErrorResponse, useRouteError } from "react-router-dom"
 
 import Layout from "@containers/Layout"
+import PageTitle from "@components/common/PageTitle"
 
 const ErrorPage = () => {
     const error = useRouteError();
 
+    if (isRouteErrorResponse(error)) {
+        return <Layout>
+            <PageTitle>{error.status}: {error.statusText}</PageTitle>
+            <p>라우터 에러!</p>
+            <Link to="">Go to index</Link>
+        </Layout>
+    }
+
     console.log(error)
 
     return <Layout noSidebar={true}>
-        <h1>{error.status}: {error.statusText}</h1>
-        <p>브라우저 콘솔 확인하세요</p>
+        <PageTitle>이런!</PageTitle>
+        <p>라우터 외의 에러입니다. 콘솔 확인하세요.</p>
         <Link to="">Go to index</Link>
     </Layout>
 }


### PR DESCRIPTION
React Router 이외의 에러로 `ErrorPage`에 이동하게 되면 에러를 알 수 없는 문제가 있었습니다.
`console.log(error)`를 추가해 콘솔창에서 발생한 에러를 확인할 수 있게 수정하였습니다.