### PR TITLE
signUp api 함수에서 아직도 axios를 쓰던 문제 해결

### DIFF
--- a/frontend/src/api/users.api.js
+++ b/frontend/src/api/users.api.js
@@ -51,7 +51,7 @@ export const signIn = async (email, password) => {
 
 export const signUp = async (email, password, username) => {
     try {
-        const res = await axios.post("sign_up/", {email, password, username})
+        const res = await client.post("sign_up/", {email, password, username})
         return res
     } catch (err) {
         let msg = ""


### PR DESCRIPTION
#34 PR에서 `axios` 사용을 `client` 사용으로 바꿨지만 `signUp`의 `axios`는 미처 바뀌지 못해서 회원가입 시 에러가 발생했습니다.
문제를 해결했습니다.