### PR TITLE
createdummies가 Comment를 생성하지 않던 문제 해결

### DIFF
--- a/backend/dummies/management/commands/_private.py
+++ b/backend/dummies/management/commands/_private.py
@@ -74,7 +74,7 @@ def create_users(n: int = 30) -> list[User]:
         except IntegrityError:
             # django.db.utils.IntegrityError: duplicate key value violates unique constraint "users_user_username_key"
             # DETAIL:  Key (username)=(andless._.) already exists.
-            raise CommandError("createdummies 명령어는 시드가 고정되어 있어 faker를 사용하는 곳들에는 항상 똑같은 결과를 출력합니다. clearall을 실행 후 다시 실행하세요.")
+            raise CommandError("clearall을 실행 후 다시 실행하세요.")
 
     for _ in range(n-len(default_users_data)):
         user = factory_user()


### PR DESCRIPTION
- `create_comments`에서 `factory_peck`를 호출하던 버그를 발견하고 수정했습니다.
- 사용되지 않는 import를 삭제했습니다.
- 시드 고정에 의미가 없어 시드 지정을 삭제했습니다.