### PR TITLE
유저 어카운트에서 이름이랑 바이오 폰트 사이즈 통일

### DIFF
--- a/frontend/src/pages/settings/Account.jsx
+++ b/frontend/src/pages/settings/Account.jsx
@@ -79,6 +79,7 @@ const Bio = styled.textarea`
     box-sizing: border-box;
     padding: 1em;
     border: none;
+    font-size: 1em;
 
     border: 1px black solid;
     border-radius: 10px;


### PR DESCRIPTION
before
![image](https://github.com/GooseMoment/Peak/assets/39623851/b4a86439-7aae-4d3a-ae7d-6df41a730e1d)

after
![image](https://github.com/GooseMoment/Peak/assets/39623851/92d6cc8a-d0a0-4c73-b598-6565b7bfa4c5)

기존 바이오에 폰트 사이즈 속성을 추가했습니다