### PR TITLE
LOGIN_EXEMPT_URLS에 admin 추가

### DIFF
--- a/backend/django_peak/settings.py
+++ b/backend/django_peak/settings.py
@@ -207,9 +207,10 @@ STORAGES = {
 }
 
 LOGIN_EXEMPT_URLS=(
-    r'sign_in/',
-    r'sign_up/',
-    r'health/ok',
+    r"^sign_in\/",
+    r"^sign_up\/",
+    r"^health\/ok",
+    r"^admin\/",
 )
 
 WEBPUSH = {


### PR DESCRIPTION
#84 PR로 인해 `(api)/admin/`의 접속이 불가능 해졌습니다.
`settings.py`의 LOGIN_EXEMPT_URLS에 `/admin/`을 추가해 어드민 페이지에 접근을 허용했습니다.