### PR TITLE
설정의 언어명을 각 언어로 표시하도록 변경

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -98,7 +98,8 @@
         "languages_and_time": {
             "title": "Languages & Time",
             "locale": {
-                "name": "Language"
+                "name": "Language",
+                "system":"Auto"
             },
             "timezone": {
                 "name": "Timezone",

--- a/frontend/public/locales/ko/translation.json
+++ b/frontend/public/locales/ko/translation.json
@@ -99,7 +99,8 @@
         "languages_and_time": {
             "title": "언어 및 시간",
             "locale": {
-                "name": "언어"
+                "name": "언어",
+                "system":"자동"
             },
             "timezone": {
                 "name": "시간대",

--- a/frontend/src/pages/settings/LanguagesAndTime.jsx
+++ b/frontend/src/pages/settings/LanguagesAndTime.jsx
@@ -1,9 +1,11 @@
+import { useMemo } from "react"
+
 import Switch from "@components/settings/SettingSwitch"
 import PageTitle from "@components/common/PageTitle"
 import Section, { Name, Value } from "@components/settings/Section"
 import Select from "@components/settings/Select"
 
-import timezones from "@assets/settings/timezones.json"
+import timezonesData from "@assets/settings/timezones.json"
 
 import { useTranslation } from "react-i18next"
 
@@ -12,10 +14,15 @@ const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone
 const LanguagesAndTime = () => {
     const { t } = useTranslation(null, {keyPrefix: "settings.languages_and_time"})
 
-    const timezoneSystemChoice = {
-        display: t("timezone.system") + ` (${browserTz})`,
-        value: "system",
-    }
+    const timezones = useMemo(() => [
+        {
+            display: t("timezone.system") + ` (${browserTz})`,
+            value: "system",
+        },
+        ...timezonesData
+    ], [t, browserTz])
+
+    const languageChoices = useMemo(() => makeLanguageChoices(t), [t])
 
     return <>
         <PageTitle>{t("title")}</PageTitle>
@@ -28,7 +35,7 @@ const LanguagesAndTime = () => {
         <Section>
             <Name>{t("timezone.name")}</Name>
             <Value>
-                <Select name="timezone" choices={[timezoneSystemChoice].concat(timezones)} />
+                <Select name="timezone" choices={timezones} />
             </Value>
         </Section>
         <Section>
@@ -47,14 +54,14 @@ const LanguagesAndTime = () => {
 }
 
 const languageNames = code => {
-    return new Intl.DisplayNames([], {
+    return new Intl.DisplayNames([code], {
         type: 'language'
     }).of(code)
 }
 
-const languageChoices = [
+const makeLanguageChoices = t => [
     {
-        display: "Default",
+        display: t("locale.system") + ` (${languageNames(navigator.language)})`,
         value: "system",
     },
     {


### PR DESCRIPTION
## Before
![Screenshot 2024-05-27 at 23 06 32](https://github.com/GooseMoment/Peak/assets/20675630/306980f5-9d19-446a-9cff-21a55764b0d4)

- 모든 언어의 목록이 시스템 언어로 번역되어 표시되었습니다.
- 모든 언어에서 'Default'로 보였습니다.

## After
![Screenshot 2024-05-27 at 23 05 32](https://github.com/GooseMoment/Peak/assets/20675630/f07864a1-262e-419f-920a-36bf42fb4518)

- 언어명이 시스템 언어에 상관없이 각 언어대로 표시됩니다.
- 'Default'가 Auto 또는 자동으로 번역되었습니다.