### PR TITLE
Fix wrong ALLOWED_HOSTS in django

### DIFF
--- a/backend/django_peak/settings.py
+++ b/backend/django_peak/settings.py
@@ -35,7 +35,8 @@ SCHEME = os.environ.get("SCHEME")
 WEB_HOSTNAME = os.environ.get("WEB_HOSTNAME")
 API_HOSTNAME = os.environ.get("API_HOSTNAME")
 
-ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ") + [API_HOSTNAME]
+API_HOSTNAME_NO_PORT = API_HOSTNAME.split(":")[0]
+ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ") + [API_HOSTNAME_NO_PORT]
 
 # Application definition
 


### PR DESCRIPTION
- 장고의 `settings.py`의 `ALLOWED_HOSTS`에는 포트 번호가 들어갈 수 없습니다. (만약 들어갈 시 400)
- `.env`의 `API_HOSTNAME`에는 포트 번호가 필요한 경우 명시하게 되어있기 때문에, `settings.py`에서 포트 번호를 제외하도록 설정했습니다.