### PR TITLE
Settings: 잘못된 클라이언트 설정 리셋 수정

### DIFF
--- a/frontend/src/utils/clientSettings.jsx
+++ b/frontend/src/utils/clientSettings.jsx
@@ -38,10 +38,10 @@ export const setClientSettingsByName = (name, value) => {
 
 export const initClientSettings = () => {
     let settings = getClientSettings()
-    if (!(settings?.language)) {
+    if (!(settings?.theme)) {
         settings = defaultSettings
     }
-    settings = Object.assign(structuredClone(defaultSettings), settings)
+    settings = Object.assign({}, defaultSettings, settings)
     localStorage.setItem(KEY_CLIENT_SETTINGS, JSON.stringify(settings))
 }
 


### PR DESCRIPTION
이제는 존재하지 않는 `language` 필드를 검사해서 클라이언트 설정을 초기화하던 문제를 수정했습니다.