### PR TITLE
api_cron 컨테이너의 느린 시작과 종료 해결

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,8 +44,11 @@ services:
     command: crond -f -l 2
     volumes:
       - ./backend/api.crontab:/etc/crontabs/root
+    init: true
     depends_on:
-      api:
+      db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     env_file:
       - ./.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,11 @@ services:
     volumes:
       - ./backend/:/backend/
       - ./backend/api.crontab:/etc/crontabs/root
+    init: true
     depends_on:
-      api:
+      db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     env_file:
       - ./.env


### PR DESCRIPTION
- `api_cron` 컨테이너의 의존성을 `api`에서 `db`와 `redis`로 변경했습니다.
- `docker-compose(.prod).yml`의 `api_cron`에 `init: true`를 추가해 컨테이너를 죽이는데 오래걸리던 문제를 해결했습니다.

## 참고한 포스트
- https://stackoverflow.com/a/65094830