### PR TITLE
사이드바 숨김을 기본으로 설정

### DIFF
--- a/frontend/src/containers/Layout.jsx
+++ b/frontend/src/containers/Layout.jsx
@@ -13,7 +13,7 @@ const startUpWidth = window.innerWidth
 const Layout = ({ children }) => {
     const [clientSetting] = useClientSetting()
 
-    const [sidebarHidden, setSidebarHidden] = useState(false)
+    const [sidebarHidden, setSidebarHidden] = useState(true)
     const [sidebarCollapsed, setSidebarCollapsed] = useState(
         startUpWidth <= WIDTH_TABLET || clientSetting["close_sidebar_on_startup"],
     )


### PR DESCRIPTION
현재 알파 테스트 서버에서 아이폰 테스트 결과, 앱 실행 시 사이드바가 잠깐 반짝하고 나타났다가 사라지는 현상이 목격되었습니다.
원래는 `sidebarHidden`의 초깃값이 참이고, `isMobile`의 값을 불러오면 그 값에 따라 `sidebarHidden`을 업데이트하는 방식이었으나,
`sidebarHidden`의 초깃값을 거짓으로 수정했습니다. 