### PR TITLE
Toast의 글씨체가 깨짐 #230 해결

### DIFF
--- a/frontend/public/global.css
+++ b/frontend/public/global.css
@@ -211,7 +211,7 @@ body {
 }
 
 .Toastify__toast-body {
-    line-height: 1.3;
+    line-height: 1.3 !important;
 }
 
 @media screen and (max-width: 500px) {
@@ -224,10 +224,10 @@ body {
     }
 
     .Toastify__toast-body {
-        font-size: 0.9em;
+        font-size: 0.9em !important;
     }
 
     .Toastify__toast--stacked[data-pos="bot"] {
-        bottom: 5em;
+        bottom: 5em !important;
     }
 }


### PR DESCRIPTION
`GlobalStyle`에서 `global.css`로 옮긴 후 스타일 적용 순서가 바뀜에 따라 토스트 글씨가 제대로 적용되지 않던 문제를 수정했습니다.