### PR TITLE
USER_DEFAULT_PROFILE_IMG 설정을 .env에 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,6 @@ DJANGO_EMAIL_HOST_PASSWORD=password
 DJANGO_EMAIL_USE_SSL=0
 DJANGO_EMAIL_USE_TLS=1
 DJANGO_FROM_EMAIL='SENDER_NAME <address@example.com>'
+
+# Static files
+USER_DEFAULT_PROFILE_IMG=https://alpha-media.peak.ooo/user_profile_imgs/default.jpg

--- a/backend/django_peak/settings.py
+++ b/backend/django_peak/settings.py
@@ -93,7 +93,7 @@ MIDDLEWARE = [
 ]
 
 AUTH_USER_MODEL = "users.User"
-USER_DEFAULT_PROFILE_IMG = "https://assets-dev.peak.ooo/user_profile_imgs%2Fdefault.jpg"
+USER_DEFAULT_PROFILE_IMG = os.environ.get("USER_DEFAULT_PROFILE_IMG")
 
 ROOT_URLCONF = 'django_peak.urls'
 


### PR DESCRIPTION
이제 유저 기본 프로필 이미지를 `.env` 파일에서 수정할 수 있습니다.

본 프로젝트에 기여하시는 분들은 `.env` 파일 맨 아래에 아래 줄을 추가해주세요.

```bash
# Static files
USER_DEFAULT_PROFILE_IMG=https://alpha-media.peak.ooo/user_profile_imgs/default.jpg

```

(맨 아래 줄 개행을 잊지 마세요!)

그리고, `api` 컨테이너를 재생성 후 실행해야 합니다.


```bash
docker compose create api
docker compose start api
```

