### PR TITLE
Remove *-systemcolor themes

### DIFF
--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -112,9 +112,7 @@
             "values": {
                 "system": "Same as system",
                 "light": "Light",
-                "light-systemcolor": "Light (with system color)",
-                "dark": "Dark",
-                "dark-systemcolor": "Dark (with system color)"
+                "dark": "Dark"
             }
         },
         "main_width": {

--- a/frontend/public/locales/ko/settings.json
+++ b/frontend/public/locales/ko/settings.json
@@ -112,9 +112,7 @@
             "values": {
                 "system": "시스템 설정대로",
                 "light": "라이트",
-                "light-systemcolor": "라이트 (시스템 컬러)",
-                "dark": "다크",
-                "dark-systemcolor": "다크 (시스템 컬러)"
+                "dark": "다크"
             }
         },
         "main_width": {

--- a/frontend/src/assets/themes.js
+++ b/frontend/src/assets/themes.js
@@ -79,20 +79,6 @@ export const light = {
     toastTheme: "light",
 }
 
-export const lightSystemcolor = Object.assign({}, light, {
-    primaryColors: Object.assign({}, light.primaryColors, {
-        primary: "AccentColor",
-    }),
-    accentColor: "AccentColor",
-    sidebar: Object.assign({}, light.sidebar, {
-        activeColor: "HighlightText",
-        activeBackgroundColor: "Highlight",
-        hoverColor: black,
-        hoverBackgroundColor: "#D9D9D9",
-        backgroundColor: "#F9F7F6",
-    }),
-})
-
 export const dark = {
     type: "dark",
     primaryColors: {
@@ -159,26 +145,10 @@ export const dark = {
     toastTheme: "dark",
 }
 
-export const darkSystemcolor = Object.assign({}, dark, {
-    primaryColors: Object.assign({}, dark.primaryColors, {
-        primary: "AccentColor",
-    }),
-    accentColor: "AccentColor",
-    sidebar: Object.assign({}, dark.sidebar, {
-        activeColor: "HighlightText",
-        activeBackgroundColor: "Highlight",
-        hoverColor: white,
-        hoverBackgroundColor: black,
-        backgroundColor: "#2F2F2F",
-    }),
-})
-
 const themes = {
     system: null,
     light: light,
-    "light-systemcolor": lightSystemcolor,
     dark: dark,
-    "dark-systemcolor": darkSystemcolor,
 }
 
 export default themes


### PR DESCRIPTION
시스템 컬러 테마가 macOS에서만 작동하는 것으로 확인되어, 지원을 종료합니다.

- `light-systemcolor`, `dark-systemcolor` 테마를 삭제했습니다.
- 이에 대응되는 번역도 삭제했습니다.