### PR TITLE
FollowButton: 언팔로우 전에 확인하기

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -274,7 +274,6 @@
         "success_cancel": "Canceled your follow request to {{username}}.",
         "error_unfollow": "Failed to unfollow @{{username}}.",
         "error_cancel": "Failed to cancel a follow request to @{{username}}.",
-        "cancel_requested": "Cancel this follow request?",
         "cancel_accepted": "Unfollow @{{username}}?",
         "button_sure": "Sure"
     },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -261,7 +261,10 @@
         "success_unfollow": "Unfollowed @{{username}}.",
         "success_cancel": "Canceled your follow request to {{username}}.",
         "error_unfollow": "Failed to unfollow @{{username}}.",
-        "error_cancel": "Failed to cancel a follow request to @{{username}}."
+        "error_cancel": "Failed to cancel a follow request to @{{username}}.",
+        "cancel_requested": "Cancel this follow request?",
+        "cancel_accepted": "Unfollow @{{username}}?",
+        "button_sure": "Sure"
     },
     "error-page": {
         "unknown_error_code": "X_X",

--- a/frontend/public/locales/ko/translation.json
+++ b/frontend/public/locales/ko/translation.json
@@ -258,10 +258,13 @@
         "success_follow": "@{{username}} 님을 팔로우 합니다.",
         "success_requested": "@{{username}} 님에게 팔로우 요청을 보냈습니다.",
         "error_follow": "@{{username}} 님에게 팔로우 요청을 보내지 못했습니다.",
-        "success_unfollow": "이제 @{{username}} 님을 팔로우하지 않습니다.",
+        "success_unfollow": "이제 @{{username}} 님을 언팔로우 했습니다.",
         "success_cancel": "@{{username}} 님에게 보낸 팔로우 요청을 취소했습니다.",
-        "error_unfollow": "@{{username}} 님의 내 팔로우를 취소하지 못했습니다.",
-        "error_cancel": "@{{username}} 님에게 보낸 팔로우 요청을 취소하지 못했습니다."
+        "error_unfollow": "@{{username}} 님을 언팔로우 하지 못했습니다.",
+        "error_cancel": "@{{username}} 님에게 보낸 팔로우 요청을 취소하지 못했습니다.",
+        "cancel_requested": "팔로우 요청을 취소할까요?",
+        "cancel_accepted": "@{{username}} 님을 언팔로우 할까요?",
+        "button_sure": "네"
     },
     "error-page": {
         "unknown_error_code": "ㅠ_ㅠ",

--- a/frontend/public/locales/ko/translation.json
+++ b/frontend/public/locales/ko/translation.json
@@ -274,7 +274,6 @@
         "success_cancel": "@{{username}} 님에게 보낸 팔로우 요청을 취소했습니다.",
         "error_unfollow": "@{{username}} 님을 언팔로우 하지 못했습니다.",
         "error_cancel": "@{{username}} 님에게 보낸 팔로우 요청을 취소하지 못했습니다.",
-        "cancel_requested": "팔로우 요청을 취소할까요?",
         "cancel_accepted": "@{{username}} 님을 언팔로우 할까요?",
         "button_sure": "네"
     },

--- a/frontend/src/components/users/FollowButton.jsx
+++ b/frontend/src/components/users/FollowButton.jsx
@@ -93,7 +93,12 @@ const FollowButton = ({ user, disabled = false }) => {
             return
         }
 
-        setConfirmationVisible(true)
+        if (following?.status === "accepted") {
+            setConfirmationVisible(true)
+            return
+        }
+
+        deleteMutation.mutate()
     }
 
     const handleConfirmation = () => {

--- a/frontend/src/components/users/FollowButton.jsx
+++ b/frontend/src/components/users/FollowButton.jsx
@@ -3,6 +3,7 @@ import { useState } from "react"
 import { useMutation, useQuery } from "@tanstack/react-query"
 
 import Button, { buttonForms } from "@components/common/Button"
+import Confirmation from "@components/common/Confirmation"
 
 import { getCurrentUsername } from "@api/client"
 import {
@@ -22,6 +23,8 @@ const FollowButton = ({ user, disabled = false }) => {
     const { t } = useTranslation(null, { keyPrefix: "follow_button" })
 
     const currentUsername = getCurrentUsername()
+
+    const [confirmationVisible, setConfirmationVisible] = useState(false)
 
     const { data: following, isPending: fetchFollowPending } = useQuery({
         queryKey: ["followings", currentUsername, user?.username],
@@ -90,31 +93,55 @@ const FollowButton = ({ user, disabled = false }) => {
             return
         }
 
+        setConfirmationVisible(true)
+    }
+
+    const handleConfirmation = () => {
+        setConfirmationVisible(false)
         deleteMutation.mutate()
     }
 
     return (
-        <Button
-            onClick={handleFollow}
-            $loading={followButtonLoading}
-            disabled={followButtonLoading || disabled}
-            $state={
-                (following?.status === "accepted" && states.success) ||
-                (following?.status === "requested" && states.link) ||
-                states.text
-            }
-            $form={
-                isHover && followAccpetedOrRequested
-                    ? buttonForms.filled
-                    : buttonForms.outlined
-            }
-            onMouseEnter={() => setIsHover(true)}
-            onMouseLeave={() => setIsHover(false)}
-        >
-            {(following?.status === "requested" && t("button_requested")) ||
-                (following?.status === "accepted" && t("button_accepted")) ||
-                t("button_follow")}
-        </Button>
+        <>
+            <Button
+                onClick={handleFollow}
+                $loading={followButtonLoading}
+                disabled={followButtonLoading || disabled}
+                $state={
+                    (following?.status === "accepted" && states.success) ||
+                    (following?.status === "requested" && states.link) ||
+                    states.text
+                }
+                $form={
+                    isHover && followAccpetedOrRequested
+                        ? buttonForms.filled
+                        : buttonForms.outlined
+                }
+                onMouseEnter={() => setIsHover(true)}
+                onMouseLeave={() => setIsHover(false)}>
+                {(following?.status === "requested" && t("button_requested")) ||
+                    (following?.status === "accepted" &&
+                        t("button_accepted")) ||
+                    t("button_follow")}
+            </Button>
+            {confirmationVisible && (
+                <Confirmation
+                    onClose={() => setConfirmationVisible(false)}
+                    question={t("cancel_" + following?.status, {
+                        username: user?.username,
+                    })}
+                    buttons={[
+                        "close",
+                        <Button
+                            key="confirm"
+                            onClick={handleConfirmation}
+                            $state={states.danger}>
+                            {t("button_sure")}
+                        </Button>,
+                    ]}
+                />
+            )}
+        </>
     )
 }
 


### PR DESCRIPTION
<img width="459" alt="Screenshot 2024-09-03 at 13 06 20" src="https://github.com/user-attachments/assets/56f6a20c-d9ab-46c6-ac2b-01582b136ea5">
<img width="505" alt="Screenshot 2024-09-03 at 13 06 14" src="https://github.com/user-attachments/assets/ca5e6ddf-89fc-46ff-8a19-14f2d1e02dfc">

팔로우 요청을 취소하려고 할 때, 언팔로우하려고 할 때 확인창을 띄웁니다.