### PR TITLE
Navbar: iOS에서 항목 터치 시 항목이 깜빡거리는 현상 해결

### DIFF
--- a/frontend/src/components/navbar/Navbar.jsx
+++ b/frontend/src/components/navbar/Navbar.jsx
@@ -99,6 +99,10 @@ const Frame = styled.nav`
     justify-content: center;
     align-items: center;
 
+    user-select: none;
+    -webkit-user-drag: none;
+    -webkit-user-select: none;
+
     display: none;
 
     ${ifMobile} {
@@ -122,6 +126,10 @@ const Box = styled.div`
     background-color: ${(p) => p.theme.navbar.backgroundColor};
     backdrop-filter: blur(5px);
     -webkit-backdrop-filter: blur(5px);
+
+    user-select: none;
+    -webkit-user-drag: none;
+    -webkit-user-select: none;
 `
 
 const Item = styled.div`
@@ -139,6 +147,14 @@ const Item = styled.div`
     align-items: center;
 
     cursor: pointer;
+
+    user-select: none;
+    -webkit-user-drag: none;
+    -webkit-user-select: none;
+
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+    -webkit-tap-highlight-color: transparent;
 
     & svg {
         font-size: 1.5em;


### PR DESCRIPTION
- iOS Safari에서 `Navbar`의 `Item`을 터치하면 항목의 배경이 어둡게 깜빡거리는 현상을 해결합니다.
- `user-select: none`을 추가하여 `Navbar`가 텍스트 선택의 대상이 되지 않도록 수정했습니다.

**Before**

https://github.com/user-attachments/assets/4e2bc45a-372b-4105-950f-07da0e14dd04

**After**

https://github.com/user-attachments/assets/38f9dd9d-06e8-40e2-b970-2c1c0618c11f

## 참고
- [iPad Safari: How to disable the quick blinking effect when a link has been hit](https://stackoverflow.com/questions/3516173/ipad-safari-how-to-disable-the-quick-blinking-effect-when-a-link-has-been-hit)

