### PR TITLE
Fix UserPage: 모바일에서의 프로젝트 목록 왼쪽 여백 감소 #267

### DIFF
--- a/frontend/src/components/users/ProjectList.jsx
+++ b/frontend/src/components/users/ProjectList.jsx
@@ -5,6 +5,8 @@ import styled, { css, useTheme } from "styled-components"
 import { getProjectColor } from "@components/project/common/palettes"
 import { Section, SectionTitle } from "@components/users/Section"
 
+import { ifMobile } from "@utils/useScreenType"
+
 import { skeletonCSS } from "@assets/skeleton"
 
 import { useTranslation } from "react-i18next"
@@ -60,6 +62,10 @@ const Projects = styled.div`
     margin-left: 1.25em;
 
     flex-wrap: wrap;
+
+    ${ifMobile} {
+        margin-left: 0;
+    }
 `
 
 const Project = styled.div`


### PR DESCRIPTION
<img width="354" alt="Screenshot 2024-10-04 at 12 09 19" src="https://github.com/user-attachments/assets/52819db0-cfa4-49d7-9280-8fa6fb6ca77c">

#267 이슈에 맞게 `UserPage`를 수정했습니다.