### PR TITLE
TimezoneMixin: pytz를 zoneinfo로 변경

### DIFF
--- a/backend/api/exceptions.py
+++ b/backend/api/exceptions.py
@@ -1,0 +1,15 @@
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class ClientTimezoneMissing(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = "The Client-Timezone header is missing."
+    default_code = "client-timezone_missing"
+
+
+class ClientTimezoneInvalid(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = "The Client-Timezone header is invalid."
+    default_code = "client-timezone_invalid"
+

--- a/backend/api/mixins.py
+++ b/backend/api/mixins.py
@@ -28,8 +28,11 @@ class TimezoneMixin:
         super().__init__(*args, **kwargs)
 
     def get_tz(self):
-        if self._tz is not None:
-            return self._tz
+        try:
+            if self._tz is not None:
+                return self._tz
+        except AttributeError:
+            TypeError("TimezoneMixin was not initialized. Place TimezoneMixin before GenericAPIView, etc.")
         
         zone = self.request.headers.get(self.TZ_HEADER, "UTC")
         

--- a/backend/api/mixins.py
+++ b/backend/api/mixins.py
@@ -2,7 +2,7 @@ from rest_framework import mixins, status
 from rest_framework.response import Response
 
 import datetime
-from pytz import timezone as timezone_from_zone, NonExistentTimeError
+import zoneinfo
 
 
 class CreateMixin(mixins.CreateModelMixin):
@@ -37,8 +37,8 @@ class TimezoneMixin:
         zone = self.request.headers.get(self.TZ_HEADER, "UTC")
         
         try:
-            tz = timezone_from_zone(zone)
-        except NonExistentTimeError:
+            tz = zoneinfo.ZoneInfo(zone)
+        except zoneinfo.ZoneInfoNotFoundError:
             tz = datetime.UTC
         
         self._tz = tz

--- a/backend/notifications/views.py
+++ b/backend/notifications/views.py
@@ -3,14 +3,14 @@ from rest_framework.response import Response
 from rest_framework.pagination import CursorPagination
 
 from api.mixins import TimezoneMixin
-from .models import Notification, WebPushSubscription, TaskReminder
-from tasks.models import Task
-from .serializers import NotificatonSerializer, WebPushSubscriptionSerializer, TaskReminderSerializer
 from api.permissions import IsUserMatch
+from tasks.models import Task
+from .models import Notification, WebPushSubscription, TaskReminder
+from .serializers import NotificatonSerializer, WebPushSubscriptionSerializer, TaskReminderSerializer
 from .utils import caculateScheduled
 
-from zoneinfo import ZoneInfo
 from datetime import datetime, time
+
 
 class IsUserMatchInReminder(permissions.IsAuthenticated):
     def has_object_permission(self, request, view, obj):
@@ -46,7 +46,7 @@ class ReminderList(mixins.CreateModelMixin, TimezoneMixin, generics.GenericAPIVi
 
         if task.due_type == "due_date":
             tz = self.get_tz()
-            nine_oclock_time = time(hour=9, minute=0, second=0, tzinfo=ZoneInfo(str(tz)))
+            nine_oclock_time = time(hour=9, minute=0, second=0, tzinfo=tz)
             converted_due_datetime = datetime.combine(date=task.due_date, time=nine_oclock_time)
         else:
             converted_due_datetime = task.due_datetime

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,4 +20,3 @@ pillow==10.3.0
 django-redis==5.4.0
 pywebpush==2.0.0
 django-rest-knox==4.2.0
-pytz==2024.1

--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -11,7 +11,7 @@ from notifications.utils import caculateScheduled
 from drawers.utils import normalize_drawer_order
 
 from datetime import datetime, time
-from zoneinfo import ZoneInfo
+
 
 class TaskDetail(mixins.RetrieveModelMixin,
                     mixins.UpdateModelMixin,
@@ -60,7 +60,7 @@ class TaskDetail(mixins.RetrieveModelMixin,
                     if new_due_type == "due_date":
                         tz = self.get_tz()
                         converted_due_date = datetime.fromisoformat(new_due_date)
-                        nine_oclock_time = time(hour=9, minute=0, second=0, tzinfo=ZoneInfo(str(tz)))
+                        nine_oclock_time = time(hour=9, minute=0, second=0, tzinfo=tz)
                         converted_due_datetime = datetime.combine(converted_due_date, nine_oclock_time)
                     else:
                         converted_due_datetime = datetime.fromisoformat(new_due_datetime)


### PR DESCRIPTION
- pytz 라이브러리와 `datetime.combine`을 함께 사용하면 역사적 시간대가 잡히는 문제가 보고되어, `TimezoneMixin`과 본 프로젝트 전체에서 pytz 라이브러리 사용을 중단하고 파이썬 내장 [zoneinfo](https://docs.python.org/3/library/zoneinfo.html#) 라이브러리로 변경했습니다.
- `TimezoneMixin`에서 `AttributeError`가 발생하는 상황이 있어 에러 메시지를 추가했습니다.