### PR TITLE
NotificationsPage: searchParam 추가 시 replace

### DIFF
--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -69,7 +69,7 @@ const NotificationsPage = () => {
     const lastDate = useRef(null)
     useEffect(() => {
         lastDate.current = null
-        setSearchParams({ active: activeFilter })
+        setSearchParams({ active: activeFilter }, { replace: true })
     }, [activeFilter])
 
     const header = (


### PR DESCRIPTION
- 전: `/app/notifications/`에 접속하면 `?active=all`이 추가되면서 히스토리가 하나 추가되었습니다. (뒤로가기하면 여전히 알림 페이지)
- 후: `?active=all`이 추가될 때 `replace`가 되면서 히스토리 개수에 변화가 없습니다. (뒤로 가기하면 정상적으로 이전 페이지로 돌아감)