### PR TITLE
SettingsPage: Select 너비 조정 & Account 여백 조정

### DIFF
--- a/frontend/src/components/settings/Select.jsx
+++ b/frontend/src/components/settings/Select.jsx
@@ -46,6 +46,8 @@ const StyledSelect = styled.select`
     line-height: 1.5em;
     padding: 0.5em 3.5em 0.5em 1em;
 
+    max-width: 100%;
+
     margin: 0;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;

--- a/frontend/src/pages/settings/Account.jsx
+++ b/frontend/src/pages/settings/Account.jsx
@@ -16,7 +16,7 @@ import Input from "@components/sign/Input"
 
 import { getMe, patchUser } from "@api/users.api"
 
-import useScreenType from "@utils/useScreenType"
+import useScreenType, { ifMobile } from "@utils/useScreenType"
 
 import queryClient from "@queries/queryClient"
 
@@ -91,8 +91,10 @@ const Account = () => {
                         username={user.username}
                     />
                     <NameEmail>
-                        <Username>@{user.username}</Username>
-                        <Email>{user.email}</Email>
+                        <Username title={"@" + user.username}>
+                            @{user.username}
+                        </Username>
+                        <Email title={user.email}>{user.email}</Email>
                     </NameEmail>
                 </ImgNameEmailContainer>
             </Section>
@@ -167,20 +169,37 @@ const ImgNameEmailContainer = styled.div`
     justify-content: start;
     align-items: center;
     gap: 2.5em;
+    min-width: 0;
+
+    ${ifMobile} {
+        gap: 1.5em;
+    }
 `
 
 const NameEmail = styled.div`
+    position: relative;
     display: flex;
     gap: 1em;
     flex-direction: column;
+    min-width: 0;
 `
 
 const Username = styled.div`
     font-weight: 600;
     font-size: 1.25em;
+
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 `
 
-const Email = styled.div``
+const Email = styled.div`
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`
 
 const Bio = styled.textarea`
     height: 7em;


### PR DESCRIPTION
## `Select`에 최대 너비 추가

- 전:
<img width="306" alt="Screenshot 2024-10-08 at 21 53 15" src="https://github.com/user-attachments/assets/188cfbcc-adf2-4898-92e9-86d56277e29d">

- 후:
<img width="306" alt="Screenshot 2024-10-08 at 21 53 26" src="https://github.com/user-attachments/assets/0302969e-b514-4cb6-b6ea-cf3054855196">

## Account 사진과 유저네임 간 여백 조정

모바일 화면에서의 여백을 조정하고 유저네임과 이메일이 너무 길면 말줄임표로 짧아지도록 조정했습니다.

- 전:
<img width="306" alt="Screenshot 2024-10-08 at 21 53 40" src="https://github.com/user-attachments/assets/d5beb068-cf6e-40a6-b146-636b6b1e6eb1">

- 후:
<img width="306" alt="Screenshot 2024-10-08 at 21 53 33" src="https://github.com/user-attachments/assets/9ee705a1-641c-4814-bbe3-fb74f300ae8f">
