### PR TITLE
설정>계정: 이메일이 짤리던 문제 해결

### DIFF
--- a/frontend/src/pages/settings/Account.jsx
+++ b/frontend/src/pages/settings/Account.jsx
@@ -197,7 +197,7 @@ const Username = styled.div`
 const Email = styled.div`
     min-width: 0;
     white-space: nowrap;
-    overflow: hidden;
+    overflow-x: clip;
     text-overflow: ellipsis;
 `
 


### PR DESCRIPTION
**설정** > **계정**에서 표시되는 이메일의 `g`, `p`, `q` 등의 알파벳이 짤려서 표시되던 문제를 해결했습니다.

**Before**
<img width="367" alt="Screenshot 2025-02-03 at 20 42 40" src="https://github.com/user-attachments/assets/5e6a0597-4f6b-4cc3-9b0a-65a371cb5dc0" />


**After**
<img width="367" alt="Screenshot 2025-02-03 at 20 42 33" src="https://github.com/user-attachments/assets/dbf6acd3-7825-4097-85b4-fc6708b2afb8" />
