### PR TITLE
모바일용 정렬 뷰 추가

### DIFF
--- a/frontend/src/components/common/ModalBottomSheet.jsx
+++ b/frontend/src/components/common/ModalBottomSheet.jsx
@@ -9,7 +9,7 @@ import "react-spring-bottom-sheet/dist/style.css"
 export const Header = ({
     title = null,
     icon = null,
-    handleBack = () => {},
+    handleBack = null,
     closeSheet,
 }) => {
     return (

--- a/frontend/src/components/drawers/Drawer.jsx
+++ b/frontend/src/components/drawers/Drawer.jsx
@@ -271,7 +271,7 @@ const Drawer = ({ project, drawer, color }) => {
                     title={t("sort.task_title")}
                     items={sortMenuItems}
                     selectedButtonPosition={selectedSortMenuPosition}
-                    onClose={()=>setIsSortMenuOpen(false)}
+                    onClose={() => setIsSortMenuOpen(false)}
                     ordering={ordering}
                     setOrdering={setOrdering}
                 />

--- a/frontend/src/components/drawers/Drawer.jsx
+++ b/frontend/src/components/drawers/Drawer.jsx
@@ -18,7 +18,7 @@ import {
     SkeletonDrawer,
     SkeletonInboxDrawer,
 } from "@components/project/skeletons/SkeletonProjectPage"
-import SortMenu from "@components/project/sorts/SortMenu"
+import SortMenuSelector from "@components/project/sorts/SortMenuSelector"
 import DrawerTask from "@components/tasks/DrawerTask"
 
 import { deleteDrawer } from "@api/drawers.api"
@@ -267,10 +267,11 @@ const Drawer = ({ project, drawer, color }) => {
                 />
             )}
             {isSortMenuOpen && (
-                <SortMenu
+                <SortMenuSelector
                     title={t("sort.task_title")}
                     items={sortMenuItems}
                     selectedButtonPosition={selectedSortMenuPosition}
+                    onClose={()=>setIsSortMenuOpen(false)}
                     ordering={ordering}
                     setOrdering={setOrdering}
                 />

--- a/frontend/src/components/project/sorts/SortMenuMobile.jsx
+++ b/frontend/src/components/project/sorts/SortMenuMobile.jsx
@@ -5,13 +5,7 @@ import ModalBottomSheet, { Header } from "@components/common/ModalBottomSheet"
 import FeatherIcon from "feather-icons-react"
 import { useTranslation } from "react-i18next"
 
-const SortMenuMobile = ({
-    title,
-    items,
-    onClose,
-    ordering,
-    setOrdering,
-}) => {
+const SortMenuMobile = ({ title, items, onClose, ordering, setOrdering }) => {
     const { t } = useTranslation(null, { keyPrefix: "project.sort" })
 
     return (
@@ -64,9 +58,7 @@ const DisplayBox = styled.div`
         top: 0;
         stroke-width: 3px;
         color: ${(props) =>
-            props.$isSelected
-                ? props.theme.textColor
-                : "transparent"};
+            props.$isSelected ? props.theme.textColor : "transparent"};
     }
 `
 

--- a/frontend/src/components/project/sorts/SortMenuMobile.jsx
+++ b/frontend/src/components/project/sorts/SortMenuMobile.jsx
@@ -1,0 +1,79 @@
+import styled from "styled-components"
+
+import ModalBottomSheet, { Header } from "@components/common/ModalBottomSheet"
+
+import FeatherIcon from "feather-icons-react"
+import { useTranslation } from "react-i18next"
+
+const SortMenuMobile = ({
+    title,
+    items,
+    onClose,
+    ordering,
+    setOrdering,
+}) => {
+    const { t } = useTranslation(null, { keyPrefix: "project.sort" })
+
+    return (
+        <ModalBottomSheet
+            headerContent={
+                <Header
+                    title={t("title", { title: title })}
+                    closeSheet={onClose}
+                />
+            }
+            onClose={onClose}>
+            <ContentBox>
+                <CLine />
+                {items.map((item) => (
+                    <DisplayBox
+                        key={item.display}
+                        onClick={() => setOrdering(item.context)}
+                        $isSelected={item.context === ordering}>
+                        <FeatherIcon icon="check" />
+                        {item.display}
+                    </DisplayBox>
+                ))}
+            </ContentBox>
+        </ModalBottomSheet>
+    )
+}
+
+const ContentBox = styled.div`
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    gap: 1em;
+    margin: 1em 2em;
+`
+
+const DisplayBox = styled.div`
+    display: flex;
+    justify-content: flex-start;
+    font-weight: normal;
+    font-size: 1em;
+    color: ${(p) => p.theme.textColor};
+    margin-bottom: 1em;
+    cursor: pointer;
+    gap: 0.1em;
+
+    & svg {
+        aspect-ratio: 1;
+        width: 16px;
+        height: 16px;
+        top: 0;
+        stroke-width: 3px;
+        color: ${(props) =>
+            props.$isSelected
+                ? props.theme.textColor
+                : "transparent"};
+    }
+`
+
+const CLine = styled.div`
+    border-top: thin solid ${(p) => p.theme.grey};
+    width: 100%;
+    margin-bottom: 1em;
+`
+
+export default SortMenuMobile

--- a/frontend/src/components/project/sorts/SortMenuMobile.jsx
+++ b/frontend/src/components/project/sorts/SortMenuMobile.jsx
@@ -1,3 +1,5 @@
+import { useState } from "react"
+
 import styled from "styled-components"
 
 import ModalBottomSheet, { Header } from "@components/common/ModalBottomSheet"
@@ -8,12 +10,20 @@ import { useTranslation } from "react-i18next"
 const SortMenuMobile = ({ title, items, onClose, ordering, setOrdering }) => {
     const { t } = useTranslation(null, { keyPrefix: "project.sort" })
 
+    // ordering 임시 상태 추가
+    const [temporaryOrdering, setTemporaryOrdering] = useState(ordering)
+
+    const handleClose = () => {
+        setOrdering(temporaryOrdering)
+        onClose()
+    }
+
     return (
         <ModalBottomSheet
             headerContent={
                 <Header
                     title={t("title", { title: title })}
-                    closeSheet={onClose}
+                    closeSheet={handleClose}
                 />
             }
             onClose={onClose}>
@@ -22,8 +32,8 @@ const SortMenuMobile = ({ title, items, onClose, ordering, setOrdering }) => {
                 {items.map((item) => (
                     <DisplayBox
                         key={item.display}
-                        onClick={() => setOrdering(item.context)}
-                        $isSelected={item.context === ordering}>
+                        onClick={() => setTemporaryOrdering(item.context)}
+                        $isSelected={item.context === temporaryOrdering}>
                         <FeatherIcon icon="check" />
                         {item.display}
                     </DisplayBox>

--- a/frontend/src/components/project/sorts/SortMenuSelector.jsx
+++ b/frontend/src/components/project/sorts/SortMenuSelector.jsx
@@ -1,0 +1,31 @@
+import useScreenType from "@utils/useScreenType"
+
+import SortMenuMobile from "./SortMenuMobile"
+import SortMenu from "./SortMenu"
+
+const SortMenuSelector = ({
+    title,
+    items,
+    selectedButtonPosition = ()=>{},
+    onClose = ()=>{},
+    ordering,
+    setOrdering
+}) => {
+    const { isMobile } = useScreenType()
+
+    return isMobile ? 
+        <SortMenuMobile
+            title={title}
+            items={items}
+            onClose={onClose}
+            ordering={ordering}
+            setOrdering={setOrdering}/> 
+        : <SortMenu
+            title={title}
+            items={items}
+            selectedButtonPosition={selectedButtonPosition}
+            ordering={ordering}
+            setOrdering={setOrdering}/>
+}
+
+export default SortMenuSelector

--- a/frontend/src/components/project/sorts/SortMenuSelector.jsx
+++ b/frontend/src/components/project/sorts/SortMenuSelector.jsx
@@ -1,31 +1,35 @@
-import useScreenType from "@utils/useScreenType"
-
-import SortMenuMobile from "./SortMenuMobile"
 import SortMenu from "./SortMenu"
+import SortMenuMobile from "./SortMenuMobile"
+
+import useScreenType from "@utils/useScreenType"
 
 const SortMenuSelector = ({
     title,
     items,
-    selectedButtonPosition = ()=>{},
-    onClose = ()=>{},
+    selectedButtonPosition = () => {},
+    onClose = () => {},
     ordering,
-    setOrdering
+    setOrdering,
 }) => {
     const { isMobile } = useScreenType()
 
-    return isMobile ? 
+    return isMobile ? (
         <SortMenuMobile
             title={title}
             items={items}
             onClose={onClose}
             ordering={ordering}
-            setOrdering={setOrdering}/> 
-        : <SortMenu
+            setOrdering={setOrdering}
+        />
+    ) : (
+        <SortMenu
             title={title}
             items={items}
             selectedButtonPosition={selectedButtonPosition}
             ordering={ordering}
-            setOrdering={setOrdering}/>
+            setOrdering={setOrdering}
+        />
+    )
 }
 
 export default SortMenuSelector

--- a/frontend/src/pages/ProjectPage.jsx
+++ b/frontend/src/pages/ProjectPage.jsx
@@ -215,7 +215,7 @@ const ProjectPage = () => {
                     title={t("sort.drawer_title")}
                     items={sortMenuItems}
                     selectedButtonPosition={selectedSortMenuPosition}
-                    onClose={()=>setIsSortMenuOpen(false)}
+                    onClose={() => setIsSortMenuOpen(false)}
                     ordering={ordering}
                     setOrdering={setOrdering}
                 />

--- a/frontend/src/pages/ProjectPage.jsx
+++ b/frontend/src/pages/ProjectPage.jsx
@@ -18,7 +18,7 @@ import DrawerEdit from "@components/project/edit/DrawerEdit"
 import ProjectEdit from "@components/project/edit/ProjectEdit"
 import { SkeletonProjectPage } from "@components/project/skeletons/SkeletonProjectPage"
 import SortIcon from "@components/project/sorts/SortIcon"
-import SortMenu from "@components/project/sorts/SortMenu"
+import SortMenuSelector from "@components/project/sorts/SortMenuSelector"
 
 import { getDrawersByProject } from "@api/drawers.api"
 import { deleteProject, getProject } from "@api/projects.api"
@@ -211,10 +211,11 @@ const ProjectPage = () => {
                 ))
             )}
             {isSortMenuOpen && (
-                <SortMenu
+                <SortMenuSelector
                     title={t("sort.drawer_title")}
                     items={sortMenuItems}
                     selectedButtonPosition={selectedSortMenuPosition}
+                    onClose={()=>setIsSortMenuOpen(false)}
                     ordering={ordering}
                     setOrdering={setOrdering}
                 />


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/f31e6332-8848-4d29-a4a4-2f124a93b61a" width="200"/>
<img src="https://github.com/user-attachments/assets/f9045dc0-f512-456c-99d2-4b4467163442" width="200"/>

모바일용 정렬 뷰를 추가하였습니다.

* 현재 정렬메뉴(모바일, 데스크탑 모두)의 경우, 정렬 기준을 선택할 때마다 새로고침되어 화면이 깜빡깜빡거립니다..