### PR TITLE
랜덤 리뷰어 지정 액션 추가

### DIFF
--- a/.github/workflows/reviewer.yaml
+++ b/.github/workflows/reviewer.yaml
@@ -1,0 +1,19 @@
+name: Random Reviewer Discord
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  assign-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign random reviewer
+        uses: JedBeom/random-reviewer-discord@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          candidates: ${{ secrets.CANDIDATES }}
+          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          template: "🎉 <@{userID}> 님이 [#{prNumber} PR]({prURL}) 리뷰어로 당첨!"

--- a/.github/workflows/reviewer.yaml
+++ b/.github/workflows/reviewer.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  pull-requests: write
+
 jobs:
   assign-reviewer:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- [random-reviewer-discord](https://github.com/JedBeom/random-reviewer-discord) 액션을 추가했습니다.
- PR을 올릴 때 리뷰어가 지정되어 있으면 봇은 아무 행동을 하지 않습니다. 그러니 리뷰어가 정해진 PR은 PR 업로더가 수동으로 노티를 주는 게 방법일 것 같습니다.