### PR TITLE
eslint에 no-use-before-define 규칙 추가

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -53,8 +53,8 @@ export default [
                 "error",
                 {
                     functions: false,
-                    classes: false,
-                    variables: true,
+                    classes: true,
+                    variables: false,
                     allowNamedExports: false,
                 },
             ],

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -49,6 +49,15 @@ export default [
                     ],
                 },
             ],
+            "no-use-before-define": [
+                "error",
+                {
+                    functions: false,
+                    classes: false,
+                    variables: true,
+                    allowNamedExports: false,
+                },
+            ],
         },
     },
 ]

--- a/frontend/src/pages/SocialExplorePage.jsx
+++ b/frontend/src/pages/SocialExplorePage.jsx
@@ -37,6 +37,9 @@ const SocialExplorePage = () => {
         refetchOnWindowFocus: false,
     })
 
+    // useRef로 대체??
+    const [searchQuery, setSearchQuery] = useState("")
+
     const {
         data: foundPage,
         fetchNextPage: fetchNextFoundPage,
@@ -50,9 +53,6 @@ const SocialExplorePage = () => {
         refetchOnWindowFocus: false,
         enabled: false,
     })
-
-    // useRef로 대체??
-    const [searchQuery, setSearchQuery] = useState("")
 
     useEffect(() => {
         if (searchQuery.length !== 0) refetchFound()


### PR DESCRIPTION
현재 `/social/explore` 접속 시 오류가 발생하는 문제가 있습니다. #312 PR에서 `SocialExplorePage` 속 `searchQuery` 변수를 `queryKey`에 추가하면서 변수가 초기화되기 전에 접근하게 되어 발생하는 오류입니다.

- `SocialExplorePage`의 `searchQuery` 초기화 구문을 `useInfinity` 함수보다 위로 이동해서 초기화가 먼저 실행되도록 했습니다.
- `eslint.config.js`에 `no-use-before-define` 규칙이 에러를 발생시키도록 설정했습니다. ([ESLint 문서](https://eslint.org/docs/latest/rules/no-use-before-define#options)) 클래스, 그리고 같은 스코프에 있는 변수만 규칙이 적용되며, 함수와 상위 스코프의 변수에는 변함없이 규칙이 적용되지 않습니다.