### PR TITLE
TOTP 보안키를 textarea로 변경 외

### DIFF
--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -66,6 +66,7 @@
             "ask_delete": "Delete the one-time passcode authentication?",
             "qrcode_description": "Scan this QR code with your preferred authentication app. Enter the numbers from the app below to complete TOTP registration.",
             "secret_manual": "Or, you can enter the secret code manually:",
+            "copy_success": "Copied the secret code to the clipboard.",
             "input_placeholder": "6-digit code",
             "enter": "Enter",
             "cancel": "Cancel",

--- a/frontend/public/locales/ko/settings.json
+++ b/frontend/public/locales/ko/settings.json
@@ -66,6 +66,7 @@
             "ask_delete": "일회용 코드 인증을 삭제할까요?",
             "qrcode_description": "인증기 앱으로 QR 코드를 스캔하세요. 앱에 표시되는 숫자를 아래 입력하면 등록이 완료됩니다.",
             "secret_manual": "또는, 보안 키를 수동으로 입력할 수 있습니다:",
+            "copy_success": "수동 보안키를 클립보드로 복사했습니다.",
             "input_placeholder": "6자리 코드",
             "enter": "입력",
             "cancel": "취소",

--- a/frontend/src/components/settings/ProfileImg.jsx
+++ b/frontend/src/components/settings/ProfileImg.jsx
@@ -77,7 +77,7 @@ const ProfileImg = ({ profile_img, username }) => {
 
     return (
         <ProfileImgContainer>
-            <Img src={profile_img} />
+            <Img src={profile_img} draggable="false" />
             <ProfileImgOverlay onClick={clickInput}>
                 <ImageIcon />
             </ProfileImgOverlay>
@@ -102,6 +102,9 @@ const ProfileImg = ({ profile_img, username }) => {
 
 const ProfileImgContainer = styled.div`
     position: relative;
+
+    user-select: none;
+    -webkit-user-select: none;
 `
 
 const ProfileImgOverlay = styled.div`

--- a/frontend/src/components/settings/Section.jsx
+++ b/frontend/src/components/settings/Section.jsx
@@ -11,9 +11,15 @@ const Section = styled.section`
     }
 `
 
-export const Name = styled.h2``
+export const Name = styled.h2`
+    user-select: none;
+    -webkit-user-drag: none;
+`
 
 export const Description = styled.span`
+    user-select: none;
+    -webkit-user-drag: none;
+
     display: block;
     margin-top: 1em;
     font-weight: 400;

--- a/frontend/src/components/settings/Section.jsx
+++ b/frontend/src/components/settings/Section.jsx
@@ -14,11 +14,13 @@ const Section = styled.section`
 export const Name = styled.h2`
     user-select: none;
     -webkit-user-drag: none;
+    -webkit-user-select: none;
 `
 
 export const Description = styled.span`
     user-select: none;
     -webkit-user-drag: none;
+    -webkit-user-select: none;
 
     display: block;
     margin-top: 1em;

--- a/frontend/src/components/sign/Input.jsx
+++ b/frontend/src/components/sign/Input.jsx
@@ -54,6 +54,7 @@ const IconBox = styled.span`
 
     & svg,
     & img {
+        top: 0;
         height: 1em;
     }
 `

--- a/frontend/src/components/sign/Showcase.jsx
+++ b/frontend/src/components/sign/Showcase.jsx
@@ -42,6 +42,7 @@ const DisplayArea = styled.div`
     flex-direction: column;
     overflow: hidden;
     user-select: none;
+    -webkit-user-select: none;
     gap: 2rem;
 
     height: 70%;
@@ -79,6 +80,7 @@ const scroll = keyframes`
 
 const ActivitiesBox = styled.div`
     user-select: none;
+    -webkit-user-select: none;
 
     flex-shrink: 0;
     display: flex;

--- a/frontend/src/components/social/SocialPageTitle.jsx
+++ b/frontend/src/components/social/SocialPageTitle.jsx
@@ -38,6 +38,7 @@ const PageTitleGroup = styled.div`
     display: flex;
     gap: 0.7em;
     user-select: none;
+    -webkit-user-select: none;
 `
 
 const PageTitleButton = ({ $color, to, children }) => {

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -113,6 +113,7 @@ const Menu = styled(NavLink)`
     transition: background-color 0.15s ${cubicBeizer};
 
     user-select: none;
+    -webkit-user-select: none;
     -webkit-user-drag: none;
 
     &:hover {

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -57,11 +57,11 @@ const getMenuItems = (t) => [
         display: t("security"),
         to: "security",
     },
-    {
-        icon: "lock",
-        display: t("privacy"),
-        to: "privacy",
-    },
+    // {
+    //     icon: "lock",
+    //     display: t("privacy"),
+    //     to: "privacy",
+    // },
     {
         icon: "globe",
         display: t("languages_and_time"),
@@ -77,11 +77,11 @@ const getMenuItems = (t) => [
         display: t("appearance"),
         to: "appearance",
     },
-    {
-        icon: "heart",
-        display: t("reactions"),
-        to: "reactions",
-    },
+    // {
+    //     icon: "heart",
+    //     display: t("reactions"),
+    //     to: "reactions",
+    // },
     {
         icon: "shield",
         display: t("blocks"),

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,7 +1,7 @@
 import { Suspense, useMemo } from "react"
 import { NavLink, Outlet } from "react-router-dom"
 
-import styled, { css } from "styled-components"
+import styled from "styled-components"
 
 import { LoaderCircleFull } from "@components/common/LoaderCircle"
 import PageTitle from "@components/common/PageTitle"
@@ -24,7 +24,10 @@ const SettingsPage = () => {
             <MenuBox>
                 {menuItems.map((menuItem) => {
                     return (
-                        <Menu to={pathRoot + menuItem.to} key={menuItem.to}>
+                        <Menu
+                            draggable="false"
+                            to={pathRoot + menuItem.to}
+                            key={menuItem.to}>
                             <FeatherIcon icon={menuItem.icon} />
                             {menuItem.display}
                         </Menu>
@@ -100,7 +103,7 @@ const MenuBox = styled.div`
     margin-bottom: 2em;
 `
 
-const menuStyle = css`
+const Menu = styled(NavLink)`
     border: 1.5px solid ${(p) => p.theme.textColor};
     border-radius: 16px;
     padding: 0.5em 0.75em;
@@ -108,10 +111,9 @@ const menuStyle = css`
     font-weight: 500;
 
     transition: background-color 0.15s ${cubicBeizer};
-`
 
-const Menu = styled(NavLink)`
-    ${menuStyle}
+    user-select: none;
+    -webkit-user-drag: none;
 
     &:hover {
         background-color: ${(p) => p.theme.secondBackgroundColor};

--- a/frontend/src/pages/settings/Security.jsx
+++ b/frontend/src/pages/settings/Security.jsx
@@ -98,6 +98,10 @@ const Security = () => {
         }
     }
 
+    const onClickSecret = (e) => {
+        e.target.select()
+    }
+
     if (totpQuery.isError) {
         return <Error />
     }
@@ -151,7 +155,15 @@ const Security = () => {
                             <QRCodeImg src={totpQRData} />
                             <Text>{t("totp.qrcode_description")}</Text>
                             <Text>{t("totp.secret_manual")}</Text>
-                            <Secret>{totpSecret}</Secret>
+                            <Secret
+                                onClick={onClickSecret}
+                                autoComplete="off"
+                                autoCapitalize="off"
+                                readOnly
+                                spellCheck="false"
+                                defaultValue={totpSecret}
+                                wrap="soft"
+                            />
                             <Input
                                 icon={<FeatherIcon icon="hash" />}
                                 name="totp_code"
@@ -218,11 +230,20 @@ const Text = styled.p`
     margin-bottom: 1em;
 `
 
-const Secret = styled.div`
+const Secret = styled.textarea`
     padding: 1em;
     background-color: ${(p) => p.theme.secondBackgroundColor};
+    width: 100%;
+
+    font-size: 1em;
+    font-family: monospace !important;
+
+    box-sizing: border-box;
+    resize: none;
+
+    line-height: 1.2;
+
     margin-bottom: 1em;
-    width: min-content;
 `
 
 export default Security

--- a/frontend/src/pages/settings/Security.jsx
+++ b/frontend/src/pages/settings/Security.jsx
@@ -98,8 +98,9 @@ const Security = () => {
         }
     }
 
-    const onClickSecret = (e) => {
-        e.target.select()
+    const onClickSecret = () => {
+        navigator.clipboard.writeText(totpSecret)
+        toast.success(t("totp.copy_success"), { toastId: "totp.copy_success" })
     }
 
     if (totpQuery.isError) {
@@ -155,15 +156,9 @@ const Security = () => {
                             <QRCodeImg src={totpQRData} />
                             <Text>{t("totp.qrcode_description")}</Text>
                             <Text>{t("totp.secret_manual")}</Text>
-                            <Secret
-                                onClick={onClickSecret}
-                                autoComplete="off"
-                                autoCapitalize="off"
-                                readOnly
-                                spellCheck="false"
-                                defaultValue={totpSecret}
-                                wrap="soft"
-                            />
+                            <Secret onClick={onClickSecret}>
+                                {totpSecret}
+                            </Secret>
                             <Input
                                 icon={<FeatherIcon icon="hash" />}
                                 name="totp_code"
@@ -230,16 +225,18 @@ const Text = styled.p`
     margin-bottom: 1em;
 `
 
-const Secret = styled.textarea`
+const Secret = styled.span`
+    display: block;
+
     padding: 1em;
     background-color: ${(p) => p.theme.secondBackgroundColor};
-    width: 100%;
 
     font-size: 1em;
     font-family: monospace !important;
 
     box-sizing: border-box;
-    resize: none;
+    width: fit-content;
+    word-break: break-all;
 
     line-height: 1.2;
 


### PR DESCRIPTION
## TOTP 보안키

<img width="387" alt="Screenshot 2025-02-09 at 00 48 19" src="https://github.com/user-attachments/assets/23bdcbc6-b062-456c-88f1-e4ff7f425b42" />

TOTP 보안키의 길이가 길어 오른쪽으로 짤리던 문제가 있었습니다.

<img width="387" alt="Screenshot 2025-02-09 at 00 48 32" src="https://github.com/user-attachments/assets/7b77693f-02ef-4c0b-8e2e-5973cd54200a" />

보안키 요소를 textarea로 변경하고 자동 줄바꿈(텍스트 내에 줄바꿈 문자가 삽입되지 않음)이 되어서 짤리지 않습니다. 또한 누르면 바로 전체선택이 되도록 수정했습니다.

<img width="381" alt="Screenshot 2025-02-09 at 00 48 42" src="https://github.com/user-attachments/assets/7c5f817f-bb46-4e44-9dd9-021cb442beac" />

모바일 기기에서 도움이 되리라고 생각합니다.


## 잡다한 것

- 현재 작동하지 않는 설정 메뉴인 '공개 범위'와 '리액션'을 숨겼습니다. 라우터에서 제거한 것은 아니라서 주소로는 접근할 수 있습니다.
- 설정 메뉴가 드래그되지 않도록 수정했습니다.
- 설정 섹션 이름과 설명이 드래그되지 않도록 수정했습니다.
- 설정과 로그인/회원가입에서 사용하는 공용 `Input`의 아이콘 윗 여백을 텍스트와 일치하도록 수정했습니다.