### PR TITLE
TaskDetail, TaskCreate 모달화

### DIFF
--- a/frontend/src/components/drawers/Drawer.jsx
+++ b/frontend/src/components/drawers/Drawer.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from "react"
-import { useNavigate } from "react-router-dom"
 
 import { useInfiniteQuery, useMutation } from "@tanstack/react-query"
 import styled, { useTheme } from "styled-components"
@@ -19,6 +18,7 @@ import {
     SkeletonInboxDrawer,
 } from "@components/project/skeletons/SkeletonProjectPage"
 import SortMenuSelector from "@components/project/sorts/SortMenuSelector"
+import TaskCreateElement from "@components/project/taskDetails/TaskCreateElement"
 import DrawerTask from "@components/tasks/DrawerTask"
 
 import { deleteDrawer } from "@api/drawers.api"
@@ -36,7 +36,6 @@ import { toast } from "react-toastify"
 
 const Drawer = ({ project, drawer, color }) => {
     const theme = useTheme()
-    const navigate = useNavigate()
 
     const [collapsed, setCollapsed] = useState(false)
     const [ordering, setOrdering] = useState(null)
@@ -53,6 +52,7 @@ const Drawer = ({ project, drawer, color }) => {
     })
     const [isDrawerEditOpen, setIsDrawerEditOpen] = useState(false)
     const [isSimpleOpen, setIsSimpleOpen] = useState(false)
+    const [isCreateOpen, setCreateOpen] = useState(false)
 
     const { t } = useTranslation(null, { keyPrefix: "project" })
 
@@ -170,14 +170,7 @@ const Drawer = ({ project, drawer, color }) => {
     }
 
     const clickPlus = () => {
-        navigate(`/app/projects/${project.id}/tasks/create/`, {
-            state: {
-                project_id: project.id,
-                project_name: project.name,
-                drawer_id: drawer.id,
-                drawer_name: drawer.name,
-            },
-        })
+        setCreateOpen(true)
     }
 
     if (isLoading) {
@@ -300,6 +293,14 @@ const Drawer = ({ project, drawer, color }) => {
                     }}>
                     <DrawerEdit projectID={project.id} drawer={drawer} />
                 </ModalWindow>
+            )}
+            {isCreateOpen && (
+                <TaskCreateElement
+                    onClose={() => setCreateOpen(false)}
+                    project={project}
+                    drawer={drawer}
+                    color={color}
+                />
             )}
         </>
     )

--- a/frontend/src/components/notifications/ContentDetail.jsx
+++ b/frontend/src/components/notifications/ContentDetail.jsx
@@ -134,7 +134,7 @@ const getDisplayDateFromQuote = (quote, locale, tz) => {
 }
 
 const getPathToTaskDetail = (task) => {
-    return `/app/projects/${task.project_id}/tasks/${task.id}/detail`
+    return `/app/projects/${task.project_id}`
 }
 
 const ellipsis = css`

--- a/frontend/src/components/notifications/ContentTitle.jsx
+++ b/frontend/src/components/notifications/ContentTitle.jsx
@@ -19,10 +19,7 @@ const ContentTitle = ({ type, actionUser, payload, skeleton }) => {
     } else if (type === "task_reminder") {
         const taskURL =
             "/app/projects/" +
-            payload?.project_id +
-            "/tasks/" +
-            payload?.task +
-            "/detail"
+            payload?.project_id
         title = (
             <ContentTitleLink to={taskURL}>
                 {payload?.task_name}

--- a/frontend/src/components/notifications/ContentTitle.jsx
+++ b/frontend/src/components/notifications/ContentTitle.jsx
@@ -17,9 +17,7 @@ const ContentTitle = ({ type, actionUser, payload, skeleton }) => {
             </ContentTitleLink>
         )
     } else if (type === "task_reminder") {
-        const taskURL =
-            "/app/projects/" +
-            payload?.project_id
+        const taskURL = "/app/projects/" + payload?.project_id
         title = (
             <ContentTitleLink to={taskURL}>
                 {payload?.task_name}

--- a/frontend/src/components/project/taskDetails/TaskCreate.jsx
+++ b/frontend/src/components/project/taskDetails/TaskCreate.jsx
@@ -1,12 +1,8 @@
 import { useState } from "react"
-import { useLocation, useOutletContext } from "react-router-dom"
 
 import TaskCommonDetail from "@components/project/taskDetails/TaskCommonDetail"
 
-const TaskCreate = () => {
-    const [_, projectType, color] = useOutletContext()
-    const { state } = useLocation()
-
+const TaskCreate = ({ project, drawer, color }) => {
     const [newTask, setNewTask] = useState({
         name: "",
         assigned_at: null,
@@ -15,10 +11,10 @@ const TaskCreate = () => {
         due_datetime: null,
         reminders: [],
         priority: 0,
-        project_id: state?.project_id,
-        project_name: state?.project_name,
-        drawer: state?.drawer_id,
-        drawer_name: state?.drawer_name,
+        project_id: project.id,
+        project_name: project.name,
+        drawer: drawer.id,
+        drawer_name: drawer.name,
         memo: "",
         privacy: "public",
         completed_at: null,
@@ -28,7 +24,7 @@ const TaskCreate = () => {
         <TaskCommonDetail
             newTask={newTask}
             setNewTask={setNewTask}
-            projectType={projectType}
+            projectType={project.type}
             color={color}
             isCreating
         />

--- a/frontend/src/components/project/taskDetails/TaskCreateElement.jsx
+++ b/frontend/src/components/project/taskDetails/TaskCreateElement.jsx
@@ -1,26 +1,22 @@
-import { useNavigate, useOutletContext } from "react-router-dom"
-
 import ModalWindow from "@components/common/ModalWindow"
 import TaskCreate from "@components/project/taskDetails/TaskCreate"
 import TaskCreateMobile from "@components/project/taskDetails/mobile/TaskCreateMobile"
 
 import useScreenType from "@utils/useScreenType"
 
-const TaskCreateElement = () => {
-    const navigate = useNavigate()
+const TaskCreateElement = ({ onClose, project, drawer, color }) => {
     const { isMobile } = useScreenType()
 
-    const [projectID] = useOutletContext()
-
-    const closeCreate = () => {
-        navigate(`/app/projects/${projectID}`)
-    }
-
     return isMobile ? (
-        <TaskCreateMobile closeCreate={closeCreate} />
+        <TaskCreateMobile
+            closeCreate={onClose}
+            project={project}
+            drawer={drawer}
+            color={color}
+        />
     ) : (
-        <ModalWindow afterClose={closeCreate}>
-            <TaskCreate />
+        <ModalWindow afterClose={onClose}>
+            <TaskCreate project={project} drawer={drawer} color={color} />
         </ModalWindow>
     )
 }

--- a/frontend/src/components/project/taskDetails/TaskDetail.jsx
+++ b/frontend/src/components/project/taskDetails/TaskDetail.jsx
@@ -1,60 +1,10 @@
-import { useEffect, useState } from "react"
-import { useOutletContext, useParams } from "react-router-dom"
+import { useState } from "react"
 
-import { useQuery } from "@tanstack/react-query"
+import TaskCommonDetail from "@components/project/taskDetails/TaskCommonDetail"
+import { initializeTask } from "@components/project/taskDetails/initializeTask"
 
-import { ErrorBox } from "@components/errors/ErrorProjectPage"
-import SkeletonTaskDetail from "@components/project/skeletons/SkeletonTaskDetail"
-import TaskCommonDetail, {
-    TaskDetailBox,
-} from "@components/project/taskDetails/TaskCommonDetail"
-
-import { getTask } from "@api/tasks.api"
-
-import { useTranslation } from "react-i18next"
-
-const TaskDetail = () => {
-    const { t } = useTranslation(null, { keyPrefix: "task" })
-
-    const [_, projectType, color] = useOutletContext()
-    const { task_id } = useParams()
-
-    const {
-        data: task,
-        isLoading,
-        isError,
-        refetch,
-    } = useQuery({
-        queryKey: ["task", { taskID: task_id }],
-        queryFn: () => getTask(task_id),
-    })
-
-    const [newTask, setNewTask] = useState(task)
-
-    useEffect(() => {
-        if (task && task.reminders?.length !== 0) {
-            const deltaArray = task.reminders.map((reminder) => reminder.delta)
-            setNewTask(Object.assign({}, task, { reminders: deltaArray }))
-        } else {
-            setNewTask(task)
-        }
-    }, [task])
-
-    if (isLoading) {
-        return (
-            <TaskDetailBox>
-                <SkeletonTaskDetail />
-            </TaskDetailBox>
-        )
-    }
-
-    if (isError) {
-        return (
-            <TaskDetailBox>
-                <ErrorBox onClick={refetch}>{t("error_load_task")}</ErrorBox>
-            </TaskDetailBox>
-        )
-    }
+const TaskDetail = ({ projectType, color, task }) => {
+    const [newTask, setNewTask] = useState(() => initializeTask(task))
 
     return (
         <TaskCommonDetail

--- a/frontend/src/components/project/taskDetails/TaskDetailElement.jsx
+++ b/frontend/src/components/project/taskDetails/TaskDetailElement.jsx
@@ -1,26 +1,17 @@
-import { useNavigate, useOutletContext } from "react-router-dom"
-
 import ModalWindow from "@components/common/ModalWindow"
 import TaskDetail from "@components/project/taskDetails/TaskDetail"
 import TaskDetailMobile from "@components/project/taskDetails/mobile/TaskDetailMobile"
 
 import useScreenType from "@utils/useScreenType"
 
-const TaskDetailElement = () => {
-    const navigate = useNavigate()
+const TaskDetailElement = ({ onClose, projectType, color, task }) => {
     const { isMobile } = useScreenType()
 
-    const [projectID] = useOutletContext()
-
-    const closeDetail = () => {
-        navigate(`/app/projects/${projectID}`)
-    }
-
     return isMobile ? (
-        <TaskDetailMobile closeDetail={closeDetail} />
+        <TaskDetailMobile closeDetail={onClose} color={color} task={task} />
     ) : (
-        <ModalWindow afterClose={closeDetail}>
-            <TaskDetail />
+        <ModalWindow afterClose={onClose}>
+            <TaskDetail projectType={projectType} color={color} task={task} />
         </ModalWindow>
     )
 }

--- a/frontend/src/components/project/taskDetails/TaskElements.jsx
+++ b/frontend/src/components/project/taskDetails/TaskElements.jsx
@@ -1,4 +1,0 @@
-import TaskCreateElement from "./TaskCreateElement"
-import TaskDetailElement from "./TaskDetailElement"
-
-export { TaskCreateElement, TaskDetailElement }

--- a/frontend/src/components/project/taskDetails/initializeTask.js
+++ b/frontend/src/components/project/taskDetails/initializeTask.js
@@ -1,0 +1,7 @@
+export const initializeTask = (task) => {
+    if (task && task.reminders?.length !== 0) {
+        const deltaArray = task.reminders.map((reminder) => reminder.delta)
+        return { ...task, reminders: deltaArray }
+    }
+    return task
+}

--- a/frontend/src/components/project/taskDetails/mobile/TaskCreateMobile.jsx
+++ b/frontend/src/components/project/taskDetails/mobile/TaskCreateMobile.jsx
@@ -1,12 +1,8 @@
 import { useState } from "react"
-import { useLocation, useOutletContext } from "react-router-dom"
 
 import TaskCommonDetailMobile from "@components/project/taskDetails/mobile/TaskCommonDetailMobile"
 
-const TaskCreateMobile = ({ closeCreate }) => {
-    const [_, projectType, color] = useOutletContext()
-    const { state } = useLocation()
-
+const TaskCreateMobile = ({ closeCreate, project, drawer, color }) => {
     const [newTask, setNewTask] = useState({
         name: "",
         assigned_at: null,
@@ -15,10 +11,10 @@ const TaskCreateMobile = ({ closeCreate }) => {
         due_datetime: null,
         reminders: [],
         priority: 0,
-        project_id: state?.project_id,
-        project_name: state?.project_name,
-        drawer: state?.drawer_id,
-        drawer_name: state?.drawer_name,
+        project_id: project.id,
+        project_name: project.name,
+        drawer: drawer.id,
+        drawer_name: drawer.name,
         memo: "",
         privacy: "public",
         completed_at: null,
@@ -28,7 +24,7 @@ const TaskCreateMobile = ({ closeCreate }) => {
         <TaskCommonDetailMobile
             newTask={newTask}
             setNewTask={setNewTask}
-            projectType={projectType}
+            projectType={project.type}
             color={color}
             onClose={closeCreate}
             isCreating

--- a/frontend/src/components/project/taskDetails/mobile/TaskDetailMobile.jsx
+++ b/frontend/src/components/project/taskDetails/mobile/TaskDetailMobile.jsx
@@ -1,40 +1,10 @@
-import { useEffect, useState } from "react"
-import { useOutletContext, useParams } from "react-router-dom"
+import { useState } from "react"
 
-import { useQuery } from "@tanstack/react-query"
-
+import { initializeTask } from "@components/project/taskDetails/initializeTask"
 import TaskCommonDetailMobile from "@components/project/taskDetails/mobile/TaskCommonDetailMobile"
 
-import { getTask } from "@api/tasks.api"
-
-const TaskDetailMobile = ({ closeDetail }) => {
-    const [_, __, color] = useOutletContext()
-
-    const { task_id } = useParams()
-
-    const {
-        data: task,
-        isLoading,
-        isError,
-    } = useQuery({
-        queryKey: ["task", { taskID: task_id }],
-        queryFn: () => getTask(task_id),
-    })
-
-    const [newTask, setNewTask] = useState(task)
-
-    useEffect(() => {
-        if (task && task.reminders?.length !== 0) {
-            const deltaArray = task.reminders.map((reminder) => reminder.delta)
-            setNewTask(Object.assign({}, task, { reminders: deltaArray }))
-        } else {
-            setNewTask(task)
-        }
-    }, [task])
-
-    if (isLoading || isError) {
-        return null
-    }
+const TaskDetailMobile = ({ closeDetail, color, task }) => {
+    const [newTask, setNewTask] = useState(() => initializeTask(task))
 
     return (
         <TaskCommonDetailMobile

--- a/frontend/src/components/tasks/Task.jsx
+++ b/frontend/src/components/tasks/Task.jsx
@@ -41,15 +41,13 @@ const Task = ({ task, color }) => {
         mutation.mutate({ completed_at })
     }
 
-    const taskDetailPath = `/app/projects/${task.project_id}/tasks/${task.id}/detail`
-
     return (
         <TaskFrame
             task={task}
             color={color}
             isLoading={mutation.isPending}
             toComplete={toComplete}
-            taskDetailPath={taskDetailPath}
+            showTaskDetail
         />
     )
 }

--- a/frontend/src/components/tasks/TaskFrame.jsx
+++ b/frontend/src/components/tasks/TaskFrame.jsx
@@ -1,7 +1,8 @@
-import { Link } from "react-router-dom"
+import { useState } from "react"
 
 import styled from "styled-components"
 
+import TaskDetailElement from "@components/project/taskDetails/TaskDetailElement"
 import Priority from "@components/tasks/Priority"
 import TaskCircle from "@components/tasks/TaskCircle"
 import taskCalculation from "@components/tasks/utils/taskCalculation"
@@ -16,11 +17,13 @@ import FeatherIcon from "feather-icons-react"
 const TaskFrame = ({
     task,
     color,
-    taskDetailPath,
+    showTaskDetail,
     isLoading,
     toComplete,
     isSocial,
 }) => {
+    const [isModalOpen, setModalOpen] = useState(false)
+
     const completedAt = isSocial ? null : task.completed_at
 
     const {
@@ -33,7 +36,13 @@ const TaskFrame = ({
     } = taskCalculation(task, isSocial)
 
     const TaskName = (
-        <TaskNameBox $completed={completedAt}>{task?.name}</TaskNameBox>
+        <TaskNameBox
+            $completed={completedAt}
+            onClick={() => {
+                showTaskDetail && setModalOpen(true)
+            }}>
+            {task?.name}
+        </TaskNameBox>
     )
 
     const hasDate = task.due_type || task.assigned_at
@@ -56,13 +65,7 @@ const TaskFrame = ({
                             onClick={toComplete}
                         />
                     </Icons>
-                    {taskDetailPath ? (
-                        <NameLink draggable="false" to={taskDetailPath}>
-                            {TaskName}
-                        </NameLink>
-                    ) : (
-                        TaskName
-                    )}
+                    {TaskName}
                 </CircleName>
 
                 {hasDate && (
@@ -99,6 +102,14 @@ const TaskFrame = ({
                     </Dates>
                 )}
             </Content>
+            {isModalOpen ? (
+                <TaskDetailElement
+                    onClose={() => setModalOpen(false)}
+                    projectType={task.projectType}
+                    color={color}
+                    task={task}
+                />
+            ) : null}
         </Box>
     )
 }
@@ -113,11 +124,6 @@ const Box = styled.div`
 `
 
 const Content = styled.div`
-    min-width: 0;
-`
-
-const NameLink = styled(Link)`
-    display: flex;
     min-width: 0;
 `
 

--- a/frontend/src/components/tasks/TaskFrame.jsx
+++ b/frontend/src/components/tasks/TaskFrame.jsx
@@ -22,7 +22,7 @@ const TaskFrame = ({
     toComplete,
     isSocial,
 }) => {
-    const [isModalOpen, setModalOpen] = useState(false)
+    const [isDetailOpen, setDetailOpen] = useState(false)
 
     const completedAt = isSocial ? null : task.completed_at
 
@@ -39,7 +39,7 @@ const TaskFrame = ({
         <TaskNameBox
             $completed={completedAt}
             onClick={() => {
-                showTaskDetail && setModalOpen(true)
+                showTaskDetail && setDetailOpen(true)
             }}>
             {task?.name}
         </TaskNameBox>
@@ -102,9 +102,9 @@ const TaskFrame = ({
                     </Dates>
                 )}
             </Content>
-            {isModalOpen ? (
+            {isDetailOpen ? (
                 <TaskDetailElement
-                    onClose={() => setModalOpen(false)}
+                    onClose={() => setDetailOpen(false)}
                     projectType={task.projectType}
                     color={color}
                     task={task}

--- a/frontend/src/pages/ProjectPage.jsx
+++ b/frontend/src/pages/ProjectPage.jsx
@@ -1,12 +1,11 @@
-import { Suspense, useEffect, useMemo, useState } from "react"
-import { Outlet, useNavigate, useParams } from "react-router-dom"
+import { useEffect, useMemo, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
 
 import { useMutation, useQuery } from "@tanstack/react-query"
 import styled, { useTheme } from "styled-components"
 
 import ContextMenu from "@components/common/ContextMenu"
 import DeleteAlert from "@components/common/DeleteAlert"
-import ModalLoader from "@components/common/ModalLoader"
 import ModalWindow from "@components/common/ModalWindow"
 import PageTitle from "@components/common/PageTitle"
 import Drawer from "@components/drawers/Drawer"
@@ -19,6 +18,7 @@ import ProjectEdit from "@components/project/edit/ProjectEdit"
 import { SkeletonProjectPage } from "@components/project/skeletons/SkeletonProjectPage"
 import SortIcon from "@components/project/sorts/SortIcon"
 import SortMenuSelector from "@components/project/sorts/SortMenuSelector"
+import TaskCreateElement from "@components/project/taskDetails/TaskCreateElement"
 
 import { getDrawersByProject } from "@api/drawers.api"
 import { deleteProject, getProject } from "@api/projects.api"
@@ -51,6 +51,7 @@ const ProjectPage = () => {
         left: 0,
     })
     const [isProjectEditOpen, setIsProjectEditOpen] = useState(false)
+    const [isCreateOpen, setCreateOpen] = useState(false)
 
     const { t } = useTranslation(null, { keyPrefix: "project" })
 
@@ -122,13 +123,7 @@ const ProjectPage = () => {
     }
 
     const openInboxTaskCreate = () => {
-        navigate(`/app/projects/${project.id}/tasks/create/`, {
-            state: {
-                project_name: project.name,
-                drawer_id: project.drawers[0].id,
-                drawer_name: project.drawers[0].name,
-            },
-        })
+        setCreateOpen(true)
     }
 
     const onClickProjectErrorBox = () => {
@@ -253,9 +248,14 @@ const ProjectPage = () => {
                     <ProjectEdit project={project} />
                 </ModalWindow>
             )}
-            <Suspense key="project-page" fallback={<ModalLoader />}>
-                <Outlet context={[id, project.type, color]} />
-            </Suspense>
+            {isCreateOpen && (
+                <TaskCreateElement
+                    onClose={() => setCreateOpen(false)}
+                    project={project}
+                    drawer={project.drawers[0]}
+                    color={color}
+                />
+            )}
         </>
     )
 }

--- a/frontend/src/routers/mainRouter.jsx
+++ b/frontend/src/routers/mainRouter.jsx
@@ -25,9 +25,6 @@ const TodayPage = lazy(() => import("@pages/TodayPage"))
 const ProjectPage = lazy(() => import("@pages/ProjectPage"))
 const ProjectListPage = lazy(() => import("@pages/ProjectListPage"))
 const SettingsPage = lazy(() => import("@pages/SettingsPage"))
-const { TaskCreateElement } = lazily(
-    () => import("@components/project/taskDetails/TaskElements"),
-)
 
 const { SocialRedirector, SocialFollowingPage, SocialExplorePage } = lazily(
     () => import("@pages/chunks/SocialPages"),
@@ -161,12 +158,6 @@ const routes = [
             {
                 path: "projects/:id",
                 element: <ProjectPage />,
-                children: [
-                    {
-                        path: "tasks/create/",
-                        element: <TaskCreateElement />,
-                    },
-                ],
             },
             {
                 path: "users/:username",

--- a/frontend/src/routers/mainRouter.jsx
+++ b/frontend/src/routers/mainRouter.jsx
@@ -25,7 +25,7 @@ const TodayPage = lazy(() => import("@pages/TodayPage"))
 const ProjectPage = lazy(() => import("@pages/ProjectPage"))
 const ProjectListPage = lazy(() => import("@pages/ProjectListPage"))
 const SettingsPage = lazy(() => import("@pages/SettingsPage"))
-const { TaskCreateElement, TaskDetailElement } = lazily(
+const { TaskCreateElement } = lazily(
     () => import("@components/project/taskDetails/TaskElements"),
 )
 
@@ -165,11 +165,6 @@ const routes = [
                     {
                         path: "tasks/create/",
                         element: <TaskCreateElement />,
-                    },
-                    {
-                        path: "tasks/:task_id/detail/",
-                        id: "task",
-                        element: <TaskDetailElement />,
                     },
                 ],
             },


### PR DESCRIPTION
- 기존에는 `TaskDetail`과 `TaskCreate`를 라우터로 이동시켜 띄웠지만, 이제 모달로 띄워집니다.
- 기존에는 `Notifications`에서 `Task`를 누르면 `TaskDetail`로 이동했지만, 이제는 해당 `Task`가 있는 `ProjectPage`로 이동합니다.

TODO: 아직 검색페이지에서 검색된 `Task`를 누르면 `detail` 라우터로 이동합니다. 이는 추후에 @andless2004 님이 검색페이지 리팩토링할 때 수정하실 계획입니다.😎