### PR TITLE
Upgrade random-reviewer-discord to v0.2.1

### DIFF
--- a/.github/workflows/reviewer.yaml
+++ b/.github/workflows/reviewer.yaml
@@ -4,10 +4,12 @@ on:
   pull_request:
     types:
       - opened
+      - review_requested
       - ready_for_review
-      - reopened
-    branches:
-      - main
+  pull_request_review:
+    types:
+      - submitted
+  workflow_dispatch:
 
 permissions:
   pull-requests: write
@@ -17,10 +19,60 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run random-reviewer-discord
-        uses: JedBeom/random-reviewer-discord@v0.1.2
+        uses: JedBeom/random-reviewer-discord@v0.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          candidates: ${{ secrets.CANDIDATES }}
+          usernames: ${{ secrets.USERNAMES }}
           webhook_url: ${{ secrets.WEBHOOK_URL }}
-          template: "🎉 <@{userID}> 님이 [#{prNumber} PR]({prURL}) 리뷰어로 당첨!"
+          schedule_prs_min_age: 36
+          template_opened: |-
+            🆕 {mention} 님이 #{prNumber} 리뷰어로 당첨!
+            
+            - 풀 리퀘스트: [{prTitle} (#{prNumber})]({prURL})
+          template_ready_for_review_assigned: |-
+            🎲 {mention} 님이 #{prNumber} 리뷰어로 당첨!
+
+            - 풀 리퀘스트: [{prTitle} (#{prNumber})]({prURL})
+            - 초안 상태였다가 리뷰 받을 준비가 되었어요
+          template_ready_for_review_exist_one: |-
+            🔔 {mention} 님, #{prNumber} 풀 리퀘스트가 준비 되었어요.
+
+            - 풀 리퀘스트: [{prTitle} (#{prNumber})]({prURL})
+            - 초안 상태였다가 리뷰 받을 준비가 되었어요
+            - 전에 무작위 당첨되었거나 수동으로 지정되었어요
+          template_ready_for_review_exist_plural: |-
+            🔔 #{prNumber} 풀 리퀘스트가 준비 되었어요.
+
+            - 리뷰어 목록: {mention}
+            - 풀 리퀘스트: [{prTitle} (#{prNumber})]({prURL})
+            - 초안 상태였다가 리뷰 받을 준비가 되었어요
+            - 전에 무작위 당첨되었거나 수동으로 지정되었어요
+          template_review_requested_one: |-
+            🔄 {mention} 님, #{prNumber} 리뷰 요청을 받았어요.
+
+            - 요청한 사람: {sender}
+            - 풀 리퀘스트: [{prTitle} (#{prNumber})]({prURL})
+          template_review_requested_plural: |-
+            🔄 #{prNumber}의 리뷰어로 지정되었어요.
+
+            - 요청한 사람: {sender}
+            - 리뷰어 목록: {mention}
+            - 풀 리퀘스트: [{prTitle} (#{prNumber})]({prURL})
+          template_schedule: |-
+            ⏳ 리뷰를 기다리는 풀 리퀘스트가 있어요!
+          template_review_submitted_commented: |-
+            💬 {mention} 님, 피드백이 도착했어요.
+
+            - 리뷰어: {reviewer}
+            - 풀 리퀘스트: [{prTitle} (#{prNumber})]({prURL})
+          template_review_submitted_changes_requested: |-
+            ⚠️ {mention} 님, 수정 요청을 받았어요.
+
+            - 리뷰어: {reviewer}
+            - 풀 리퀘스트: [{prTitle} (#{prNumber})]({prURL})
+          template_review_submitted_approved: |-
+            ✅ {mention} 님, 승인을 받았어요.
+
+            - 리뷰어: {reviewer}
+            - 풀 리퀘스트: [{prTitle} (#{prNumber})]({prURL})


### PR DESCRIPTION
[random-reviewer-discord](https://github.com/JedBeom/random-reviewer-discord) 액션이 v0.2.1로 업데이트 되었다고 합니다.

- 대응하는 이벤트 추가(draft에서 전환되었을 때, 수동으로 리뷰어가 지정되었을 때, 리뷰가 제출되었을 때)
  - PR이 닫혔다가 다시 열렸을 때도 지원하지만, 우리는 풀 리퀘스트를 닫았다가 다시 열 일이 없을 것 같아서 제외했습니다.
- 이벤트별 메시지 템플릿 지정 가능
- 리뷰 리마인드 기능 추가: [`schedule.cron`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule)으로 설정 가능하다고 하는데, 깃허브의 cron은 짧으면 30분, 길면 하루 늦게 실행되는 게 예사고 딜레이도 예측이 어렵기 때문에, [`workflow_dispatch`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch)로 외부에 cron을 설정하여 액션을 수동으로 실행...하라고 들었습니다. (깃허브 API로 액션을 수동으로 실행할 수 있습니다)
  - 픽 알파서버에 타이머 설정을 해두었습니다. KST 화,금 오후 2시 정각입니다. 

...여기까지가 제가 들은 변경사항입니다. 저번 v0.1.0에서 예상치 못한 작동이 잦았기에 이번 버전에서는 부계 두 개를 새로 가입해서 [다양한 테스트 시나리오](https://github.com/JedBeom/random-reviewer-discord/pull/9)로 기능 작동을 확인하였다고 합니다.