### PR TITLE
Navbar의 transition이 처음에는 실행되지 않도록 수정

### DIFF
--- a/frontend/src/components/navbar/Navbar.jsx
+++ b/frontend/src/components/navbar/Navbar.jsx
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useState } from "react"
 import { useLocation, useNavigate } from "react-router-dom"
 
 import styled, { css } from "styled-components"
 
-import sleep from "@utils/sleep"
 import { ifMobile } from "@utils/useScreenType"
 
 import FeatherIcon from "feather-icons-react"
@@ -44,19 +43,15 @@ const Navbar = () => {
     const [activeItemVisible, setActiveItemVisible] = useState(false)
     const [transition, setTransition] = useState(false)
 
-    useEffect(() => {
-        async function enableTransitionLate() {
-            await sleep(250)
-            setTransition(true)
-        }
-        enableTransitionLate()
-    }, [])
-
     const onRefChange = useCallback(
         (node) => {
             if (!node) {
                 setActiveItemVisible(false)
                 return
+            }
+
+            if (!transition) {
+                setTimeout(() => setTransition(true), 250)
             }
 
             setActiveItemVisible(true)

--- a/frontend/src/components/navbar/Navbar.jsx
+++ b/frontend/src/components/navbar/Navbar.jsx
@@ -177,8 +177,7 @@ const ActiveItemBackground = styled.div`
     background-color: ${(p) => p.theme.navbar.activeBackgroundColor};
 
     top: 0.25em;
-    left: ${(p) =>
-        p.$left ? css`calc(${(props) => props.$left}px + 0.125em)` : "7.75em"};
+    left: calc(${(props) => props.$left}px + 0.125em);
     width: 3em;
     height: 3em;
 

--- a/frontend/src/components/navbar/Navbar.jsx
+++ b/frontend/src/components/navbar/Navbar.jsx
@@ -1,8 +1,9 @@
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { useLocation, useNavigate } from "react-router-dom"
 
-import styled from "styled-components"
+import styled, { css } from "styled-components"
 
+import sleep from "@utils/sleep"
 import { ifMobile } from "@utils/useScreenType"
 
 import FeatherIcon from "feather-icons-react"
@@ -41,6 +42,15 @@ const Navbar = () => {
 
     const [activeItemLeft, setActiveItemLeft] = useState(0)
     const [activeItemVisible, setActiveItemVisible] = useState(false)
+    const [transition, setTransition] = useState(false)
+
+    useEffect(() => {
+        async function enableTransitionLate() {
+            await sleep(250)
+            setTransition(true)
+        }
+        enableTransitionLate()
+    }, [])
 
     const onRefChange = useCallback(
         (node) => {
@@ -61,6 +71,7 @@ const Navbar = () => {
                 <ActiveItemBackground
                     $left={activeItemLeft}
                     $visible={activeItemVisible}
+                    $transition={transition}
                 />
                 {items.map((item) => (
                     <Item
@@ -171,15 +182,19 @@ const ActiveItemBackground = styled.div`
     background-color: ${(p) => p.theme.navbar.activeBackgroundColor};
 
     top: 0.25em;
-    left: calc(${(props) => props.$left}px + 0.125em);
+    left: ${(p) =>
+        p.$left ? css`calc(${(props) => props.$left}px + 0.125em)` : "7.75em"};
     width: 3em;
     height: 3em;
 
     opacity: ${(p) => (p.$visible ? 1 : 0)};
 
-    transition:
+    transition: ${(p) =>
+        p.$transition
+            ? css`
         left 0.25s var(--cubic),
-        opacity 0.25s var(--cubic);
+        opacity 0.25s var(--cubic)`
+            : css`unset`};
 
     border-radius: 50px;
 `


### PR DESCRIPTION
- Navbar 초기 로딩 시 가장 왼쪽에서 가운데 홈으로 배경이 이동하는 애니메이션이 보이는 문제를 수정했습니다.

## 영상 비교
- Before:

https://github.com/user-attachments/assets/6eb9fff0-4fec-4fda-8ba4-dce754350dac

- After:

https://github.com/user-attachments/assets/1f1c3f78-4b67-41db-98c6-01faa54e6e53

