### PR TITLE
홈에 푸시 알림 켜기 모듈 추가

### DIFF
--- a/frontend/public/locales/en/home.json
+++ b/frontend/public/locales/en/home.json
@@ -6,6 +6,12 @@
         "title": "Add a task",
         "tap_to_open": "Tap to open..."
     },
+    "allow_notification": {
+        "title": "Turn on the push notification",
+        "description": "Receive notifications from Peak.",
+        "noti_title": "⏰ Submit the assignment",
+        "noti_body": "10 mins left."
+    },
     "install_peak": {
         "title": "Install Peak as an app",
         "description": "Here's how to."

--- a/frontend/public/locales/ko/home.json
+++ b/frontend/public/locales/ko/home.json
@@ -6,6 +6,12 @@
         "title": "작업 추가",
         "tap_to_open": "눌러서 열기"
     },
+    "allow_notification": {
+        "title": "푸시 알림 켜기",
+        "description": "Peak에서 보내는 알림을 즉각 받아보세요.",
+        "noti_title": "⏰ 과제 제출하기",
+        "noti_body": "10분 전입니다."
+    },
     "install_peak": {
         "title": "Peak을 앱처럼 사용하기",
         "description": "설치 방법을 알아봅시다."

--- a/frontend/src/components/home/AllowNotification.tsx
+++ b/frontend/src/components/home/AllowNotification.tsx
@@ -1,0 +1,68 @@
+import styled from "styled-components"
+
+import Module, { Center, CenteredText, Title } from "@components/home/Module"
+
+import { useTranslation } from "react-i18next"
+
+const AllowNotification = () => {
+    const { t } = useTranslation("home", { keyPrefix: "allow_notification" })
+
+    if (window.Notification.permission !== "default") {
+        return null
+    }
+
+    return (
+        <Module to="/app/settings/notifications">
+            <Title displayArrow underline>
+                {t("title")}
+            </Title>
+            <Center>
+                <MockNoti>
+                    <AppIcon src="/logo.svg" draggable="false" />
+                    <MockNotiTexts>
+                        <MockNotiTitle>{t("noti_title")}</MockNotiTitle>
+                        <MockNotiBody>{t("noti_body")}</MockNotiBody>
+                    </MockNotiTexts>
+                </MockNoti>
+            </Center>
+            <CenteredText>{t("description")}</CenteredText>
+        </Module>
+    )
+}
+
+const MockNoti = styled.div`
+    position: relative;
+
+    display: flex;
+    gap: 0.75em;
+    align-items: center;
+
+    width: 100%;
+    max-width: 400px;
+    padding: 0.75em;
+    background-color: ${(p) => p.theme.secondBackgroundColor};
+    border-radius: 18px;
+`
+
+const AppIcon = styled.img`
+    aspect-ratio: 1/1;
+    height: 2.25em;
+    border-radius: 7px;
+`
+
+const MockNotiTexts = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.25em;
+`
+
+const MockNotiTitle = styled.h4`
+    font-weight: 600;
+    font-size: 0.85em;
+`
+
+const MockNotiBody = styled.p`
+    font-size: 0.85em;
+`
+
+export default AllowNotification

--- a/frontend/src/components/home/InstallPeak.tsx
+++ b/frontend/src/components/home/InstallPeak.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components"
 
-import Module, { CenteredText, Title } from "@components/home/Module"
+import Module, { Center, CenteredText, Title } from "@components/home/Module"
 
 import { useTranslation } from "react-i18next"
 
@@ -8,26 +8,17 @@ const InstallPeak = () => {
     const { t } = useTranslation("home", { keyPrefix: "install_peak" })
 
     return (
-        <Module>
-            <Title to="/docs/install-instruction" underline>
+        <Module to="/docs/install-instruction">
+            <Title displayArrow underline>
                 {t("title")}
             </Title>
-            <IconWrapper>
+            <Center>
                 <AppIcon src="/logo.svg" draggable="false" />
-            </IconWrapper>
+            </Center>
             <CenteredText>{t("description")}</CenteredText>
         </Module>
     )
 }
-
-const IconWrapper = styled.div`
-    display: flex;
-    justify-content: center;
-
-    width: 100%;
-
-    margin: 1em 0;
-`
 
 const AppIcon = styled.img`
     aspect-ratio: 1/1;

--- a/frontend/src/components/home/Module.tsx
+++ b/frontend/src/components/home/Module.tsx
@@ -1,22 +1,48 @@
+import { type ReactNode } from "react"
 import { Link } from "react-router-dom"
 
 import styled, { css, keyframes } from "styled-components"
 
 import { skeletonCSS } from "@assets/skeleton"
 
-const Module = styled.article`
+interface TitleProp {
+    className?: string
+    children: ReactNode
+    to?: string
+}
+
+const Module = ({ children, className, to }: TitleProp) => {
+    const module = <ModuleBox className={className}>{children}</ModuleBox>
+
+    if (to === undefined) {
+        return module
+    }
+
+    return <Link to={to}>{module}</Link>
+}
+
+const ModuleBox = styled.article`
     position: relative;
     margin-bottom: 2em;
-
-    ${(p) =>
-        p.$skeleton &&
-        css`
-            height: ${p.$height};
-            ${skeletonCSS}
-        `}
 `
 
-export const Title = ({ className, children, to, underline, loading }) => {
+interface TitleProp {
+    className?: string
+    children: ReactNode
+    to?: string
+    displayArrow?: boolean
+    underline?: boolean
+    loading?: boolean
+}
+
+export const Title = ({
+    className,
+    children,
+    to,
+    displayArrow = false,
+    underline,
+    loading = false,
+}: TitleProp) => {
     if (loading) {
         return <StyledH2 className={className} $loading />
     }
@@ -24,7 +50,7 @@ export const Title = ({ className, children, to, underline, loading }) => {
     const title = (
         <StyledH2 className={className}>
             <TitleText $underline={underline}>{children}</TitleText>{" "}
-            {to && "〉"}
+            {(to || displayArrow) && "〉"}
         </StyledH2>
     )
 
@@ -39,7 +65,7 @@ export const Title = ({ className, children, to, underline, loading }) => {
     return title
 }
 
-const StyledH2 = styled.h2`
+const StyledH2 = styled.h2<{ $loading?: boolean }>`
     font-weight: 600;
     font-size: 1em;
     margin-bottom: 0.75em;
@@ -50,7 +76,7 @@ const StyledH2 = styled.h2`
             height: 1.25em;
             width: 15em;
             max-width: 100%;
-            ${skeletonCSS}
+            ${skeletonCSS()}
         `}
 `
 
@@ -63,7 +89,7 @@ const mark = keyframes`
     }
 `
 
-const TitleText = styled.span`
+const TitleText = styled.span<{ $underline?: boolean }>`
     ${(p) =>
         p.$underline &&
         css`
@@ -78,6 +104,16 @@ export const CenteredText = styled.div`
     text-align: center;
     width: 100%;
     font-size: 0.75em;
+    word-break: keep-all;
+`
+
+export const Center = styled.div`
+    display: flex;
+    justify-content: center;
+
+    width: 100%;
+
+    margin: 1em 0;
 `
 
 export default Module

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import AddTask from "@components/home/AddTask"
+import AllowNotification from "@components/home/AllowNotification"
 import Announcements from "@components/home/Announcements"
 import AssignedToday from "@components/home/AssignedToday"
 import Header from "@components/home/Header"
@@ -9,6 +10,7 @@ const HomePage = () => {
         <>
             <Header />
             <AddTask />
+            <AllowNotification />
             <InstallPeak />
             <Announcements />
             <AssignedToday />


### PR DESCRIPTION
푸시 알림을 켤 것을 추천하는 모듈을 홈에 추가했습니다. 클릭하면 설정>알림 페이지로 이동합니다.
푸시 알림 권한 상태가 `default` 일 때만 홈에 나타납니다. 

<img width="367" alt="Screenshot 2025-02-22 at 14 50 58" src="https://github.com/user-attachments/assets/f8449b80-09f4-4f98-ab46-f1a3db6b3a7b" />

- `frontend/components/settings/Module`: 타입화하고 prop 수정이 있었습니다.