### PR TITLE
설정: '계정'을 '프로필'로 개명 외 & Bump prettier@v3.5.2

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm i
         working-directory: ./frontend
       - name: Run Prettier Check
-        run: pnpm format:check
+        run: pnpm format:check || (pnpm format:write && git diff && return 1;)
         working-directory: ./frontend
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -23,6 +23,8 @@ jobs:
         working-directory: ./frontend
   format:
     runs-on: ubuntu-latest
+    env:
+      TERM: xterm-color
     steps:
       - uses: actions/checkout@v4
       - name: Install pnpm
@@ -32,8 +34,15 @@ jobs:
       - name: Install modules
         run: pnpm i
         working-directory: ./frontend
-      - name: Run Prettier Check
-        run: pnpm format:check || (pnpm format:write>/dev/null && git diff && return 1;)
+      - name: Run Prettier Check and Show Diff
+        run: >-
+          pnpm format:check 
+          || (
+            echo;
+            pnpm prettier --version;
+            pnpm format:write>/dev/null;
+            git diff --exit-code;
+          )
         working-directory: ./frontend
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -21,10 +21,22 @@ jobs:
       - name: Check for pnpm-lock.yaml Changes
         run: git diff --exit-code pnpm-lock.yaml
         working-directory: ./frontend
+  format-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Install modules
+        run: pnpm i
+        working-directory: ./frontend
+      - name: Version
+        run: pnpm prettier --version
+        working-directory: ./frontend
   format:
     runs-on: ubuntu-latest
-    env:
-      TERM: xterm-color
     steps:
       - uses: actions/checkout@v4
       - name: Install pnpm

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -21,20 +21,6 @@ jobs:
       - name: Check for pnpm-lock.yaml Changes
         run: git diff --exit-code pnpm-lock.yaml
         working-directory: ./frontend
-  format-version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      - name: Install modules
-        run: pnpm i
-        working-directory: ./frontend
-      - name: Version
-        run: pnpm prettier --version
-        working-directory: ./frontend
   format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm i
         working-directory: ./frontend
       - name: Run Prettier Check
-        run: pnpm format:check || (pnpm format:write && git diff && return 1;)
+        run: pnpm format:check || (pnpm format:write>/dev/null && git diff && return 1;)
         working-directory: ./frontend
   lint:
     runs-on: ubuntu-latest

--- a/frontend/.prettierrc.js
+++ b/frontend/.prettierrc.js
@@ -2,6 +2,8 @@ export default {
     tabWidth: 4,
     semi: false,
     bracketSameLine: true,
+    printWidth: 80,
+    objectWrap: "preserve",
 
     plugins: ["@trivago/prettier-plugin-sort-imports"],
 

--- a/frontend/.prettierrc.js
+++ b/frontend/.prettierrc.js
@@ -2,8 +2,6 @@ export default {
     tabWidth: 4,
     semi: false,
     bracketSameLine: true,
-    printWidth: 80,
-    objectWrap: "preserve",
 
     plugins: ["@trivago/prettier-plugin-sort-imports"],
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,24 +13,24 @@ pnpm dev
 
 ## Commands
 
--   `pnpm dev`: start live dev server.
--   `pnpm build`: build
--   `pnpm lint`: Run ESLint
--   `pnpm format:check`: Run prettier check
--   `pnpm format:write`: Run prettier overwrite
+- `pnpm dev`: start live dev server.
+- `pnpm build`: build
+- `pnpm lint`: Run ESLint
+- `pnpm format:check`: Run prettier check
+- `pnpm format:write`: Run prettier overwrite
 
 ## Structure
 
--   `src/`
-    -   `api/`: API 콜백 함수
-    -   `assets/`: 소스 코드에서 참조해야 하는 데이터 및 미디어
-    -   `components/`: 페이지별 컴포넌트
-    -   `containers`: Layout
-    -   `pages/`: 페이지
-    -   `queries/`: react-query 관련
-    -   `utils/`: 유틸성 함수
-    -   `routers/`: 라우터 관련
-    -   `main.jsx`: 소스코드 시작 부분
+- `src/`
+    - `api/`: API 콜백 함수
+    - `assets/`: 소스 코드에서 참조해야 하는 데이터 및 미디어
+    - `components/`: 페이지별 컴포넌트
+    - `containers`: Layout
+    - `pages/`: 페이지
+    - `queries/`: react-query 관련
+    - `utils/`: 유틸성 함수
+    - `routers/`: 라우터 관련
+    - `main.jsx`: 소스코드 시작 부분
 
 ## PWA
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react": "^7.35.0",
         "globals": "^15.9.0",
-        "prettier": "^3.3.3",
+        "prettier": "^3.5.2",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.23.0",
         "vite": "^5.2.14"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: 5.51.3(@tanstack/react-query@5.37.1(react@18.3.1))(react@18.3.1)
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
-        version: 4.3.0(prettier@3.3.3)
+        version: 4.3.0(prettier@3.5.2)
       '@types/react':
         specifier: ^18.3.2
         version: 18.3.2
@@ -118,8 +118,8 @@ importers:
         specifier: ^15.9.0
         version: 15.9.0
       prettier:
-        specifier: ^3.3.3
-        version: 3.3.3
+        specifier: ^3.5.2
+        version: 3.5.2
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -1935,8 +1935,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.3.3:
-    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+  prettier@3.5.2:
+    resolution: {integrity: sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3152,7 +3152,7 @@ snapshots:
       '@babel/runtime': 7.24.5
       date-fns: 2.30.0
 
-  '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.3.3)':
+  '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.5.2)':
     dependencies:
       '@babel/generator': 7.17.7
       '@babel/parser': 7.24.5
@@ -3160,7 +3160,7 @@ snapshots:
       '@babel/types': 7.17.0
       javascript-natural-sort: 0.7.1
       lodash: 4.17.21
-      prettier: 3.3.3
+      prettier: 3.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4494,7 +4494,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.3.3: {}
+  prettier@3.5.2: {}
 
   prop-types@15.8.1:
     dependencies:

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -4,7 +4,7 @@
     },
     "menus": {
         "title": "Settings",
-        "account": "Account",
+        "profile": "Profile",
         "general": "General",
         "security": "Security",
         "privacy": "Privacy",
@@ -15,28 +15,15 @@
         "blocks": "Blocks",
         "info": "Info"
     },
-    "account": {
+    "profile": {
         "display_name": "Display name",
         "display_name_placeholder": "Your awesome name",
         "bio": "Bio",
         "header_color": "Header Color",
         "bio_placeholder": "Tell me who you are",
         "button_submit": "Save",
-        "change_password": "Change password",
-        "section_open": "Open",
-        "section_close": "Close",
-        "current_password": "Current password",
-        "new_password": "New password",
-        "new_password_again": "New password (Type again)",
-        "button_change": "Change",
-        "account_edited": "Account was edited.",
-        "account_fail": "Couldn't save. Try again.",
-        "password_too_short": "Password should be more than 8 characters.",
-        "password_is_same": "New password should be different with current password.",
-        "password_not_match": "New password does not match.",
-        "password_wrong": "Current password is wrong.",
-        "password_change_success": "Password was changes.",
-        "password_change_error": "Error occured while changing password.",
+        "profile_edited": "Changes were saved.",
+        "profile_fail": "Couldn't save. Try again.",
         "button_apply": "Crop",
         "button_cancel": "Cancel"
     },
@@ -61,6 +48,19 @@
         }
     },
     "security": {
+        "password_change": {
+            "name": "Change password",
+            "current_password": "Current password",
+            "new_password": "New password",
+            "new_password_again": "New password (Type again)",
+            "button_change": "Change",
+            "password_too_short": "Password should be more than 8 characters.",
+            "password_is_same": "New password should be different with current password.",
+            "password_not_match": "New password does not match.",
+            "password_wrong": "Current password is wrong.",
+            "password_change_success": "Password was changes.",
+            "password_change_error": "Error occured while changing password."
+        },
         "totp": {
             "name": "Two-Factor Authentication: One-Time Passcode",
             "description": "Using one-time passcode(TOTP) enhances security.",

--- a/frontend/public/locales/ko/settings.json
+++ b/frontend/public/locales/ko/settings.json
@@ -4,7 +4,7 @@
     },
     "menus": {
         "title": "설정",
-        "account": "계정",
+        "profile": "프로필",
         "general": "일반",
         "security": "보안",
         "privacy": "공개 범위",
@@ -15,28 +15,15 @@
         "blocks": "차단",
         "info": "정보"
     },
-    "account": {
+    "profile": {
         "display_name": "이름",
         "display_name_placeholder": "남에게 보일 이름",
         "bio": "바이오",
         "header_color": "헤더 색상",
         "bio_placeholder": "자신을 소개하세요.",
         "button_submit": "저장",
-        "change_password": "암호 변경",
-        "section_open": "열기",
-        "section_close": "닫기",
-        "current_password": "현재 암호",
-        "new_password": "새로운 암호",
-        "new_password_again": "새로운 암호 (다시 입력)",
-        "button_change": "변경",
-        "account_edited": "변경사항을 저장했습니다.",
-        "account_fail": "저장할 수 없습니다. 다시 시도하세요.",
-        "password_too_short": "암호는 8자 이상이어야 합니다.",
-        "password_is_same": "현재 암호와 새로운 암호가 동일합니다.",
-        "password_not_match": "새로운 암호가 서로 일치하지 않습니다.",
-        "password_wrong": "현재 암호가 틀렸습니다.",
-        "password_change_success": "암호를 변경했습니다.",
-        "password_change_error": "암호 변경 중 문제가 발생했습니다.",
+        "profile_edited": "변경사항을 저장했습니다.",
+        "profile_fail": "저장할 수 없습니다. 다시 시도하세요.",
         "button_apply": "자르기",
         "button_cancel": "취소"
     },
@@ -61,6 +48,19 @@
         }
     },
     "security": {
+        "password_change": {
+            "name": "암호 변경",
+            "current_password": "현재 암호",
+            "new_password": "새로운 암호",
+            "new_password_again": "새로운 암호 (다시 입력)",
+            "button_change": "변경",
+            "password_too_short": "암호는 8자 이상이어야 합니다.",
+            "password_is_same": "현재 암호와 새로운 암호가 동일합니다.",
+            "password_not_match": "새로운 암호가 서로 일치하지 않습니다.",
+            "password_wrong": "현재 암호가 틀렸습니다.",
+            "password_change_success": "암호를 변경했습니다.",
+            "password_change_error": "암호 변경 중 문제가 발생했습니다."
+        },
         "totp": {
             "name": "2단계 인증: 일회용 코드",
             "description": "일회용 코드(TOTP)를 사용하면 보안을 향상할 수 있습니다.",

--- a/frontend/src/components/common/Switch.jsx
+++ b/frontend/src/components/common/Switch.jsx
@@ -30,6 +30,8 @@ const Label = styled.label`
     --toggle-wider: 3em;
     --color-grey: ${(p) => p.theme.grey};
     --color-green: ${(p) => p.theme.accentColor};
+
+    cursor: pointer;
 `
 
 const Checkbox = styled.input`

--- a/frontend/src/components/home/Header.jsx
+++ b/frontend/src/components/home/Header.jsx
@@ -37,7 +37,7 @@ const Header = () => {
                 <Link to="/app/notifications">
                     <FeatherIcon icon="bell" />
                 </Link>
-                <Link to="/app/settings/account">
+                <Link to="/app/settings/profile">
                     <FeatherIcon icon="settings" />
                 </Link>
             </HeaderIcons>

--- a/frontend/src/components/settings/ImageCropper.jsx
+++ b/frontend/src/components/settings/ImageCropper.jsx
@@ -21,7 +21,7 @@ const ImageCropper = ({
     const [crop, setCrop] = useState({ x: 0, y: 0 })
     const [zoom, setZoom] = useState(1)
 
-    const { t } = useTranslation("settings", { keyPrefix: "account" })
+    const { t } = useTranslation("settings", { keyPrefix: "profile" })
 
     const onCropComplete = (croppedArea, croppedAreaPixels) => {
         setCroppedAreaPixels(croppedAreaPixels)

--- a/frontend/src/components/settings/PasswordSection.jsx
+++ b/frontend/src/components/settings/PasswordSection.jsx
@@ -16,7 +16,9 @@ import { useTranslation } from "react-i18next"
 import { toast } from "react-toastify"
 
 const PasswordSection = () => {
-    const { t } = useTranslation("settings", { keyPrefix: "account" })
+    const { t } = useTranslation("settings", {
+        keyPrefix: "security.password_change",
+    })
 
     const [currentPassword, setCurrentPassword] = useState("")
     const [newPassword, setNewPassword] = useState("")
@@ -68,7 +70,7 @@ const PasswordSection = () => {
 
     return (
         <Section>
-            <Name>{t("change_password")}</Name>
+            <Name>{t("name")}</Name>
             <Value>
                 <PasswordChangeForm onSubmit={changePassword}>
                     <Input

--- a/frontend/src/components/settings/Select.jsx
+++ b/frontend/src/components/settings/Select.jsx
@@ -56,7 +56,8 @@ const StyledSelect = styled.select`
     -webkit-appearance: none;
     -moz-appearance: none;
 
-    background-image: linear-gradient(45deg, transparent 50%, gray 50%),
+    background-image:
+        linear-gradient(45deg, transparent 50%, gray 50%),
         linear-gradient(135deg, gray 50%, transparent 50%),
         linear-gradient(to right, #ccc, #ccc);
     background-position:
@@ -68,6 +69,8 @@ const StyledSelect = styled.select`
         5px 5px,
         1px 1.5em;
     background-repeat: no-repeat;
+
+    cursor: pointer;
 
     &:focus {
         background-repeat: no-repeat;

--- a/frontend/src/components/sidebar/Footer.jsx
+++ b/frontend/src/components/sidebar/Footer.jsx
@@ -59,7 +59,7 @@ const Footer = () => {
             {!isCollapsed && (
                 <SmallIcons>
                     <SidebarLink
-                        to="/app/settings/account"
+                        to="/app/settings/profile"
                         activePath="/app/settings"
                         end={false}
                         key="settings">

--- a/frontend/src/components/users/UserProfileHeader.jsx
+++ b/frontend/src/components/users/UserProfileHeader.jsx
@@ -19,7 +19,7 @@ const UserProfileHeader = ({ user, followingYou, isMine, isPending }) => {
     const theme = useTheme()
 
     const followButton = isMine ? (
-        <Link to="/app/settings/account">
+        <Link to="/app/settings/profile">
             <Button>{t("button_edit_profile")}</Button>
         </Link>
     ) : (

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -83,7 +83,7 @@ const getMenuItems = (t) => [
     //     to: "reactions",
     // },
     {
-        icon: "shield",
+        icon: "slash",
         display: t("blocks"),
         to: "blocks",
     },

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -44,8 +44,8 @@ const SettingsPage = () => {
 const getMenuItems = (t) => [
     {
         icon: "user",
-        display: t("account"),
-        to: "account",
+        display: t("profile"),
+        to: "profile",
     },
     {
         icon: "settings",

--- a/frontend/src/pages/settings/Profile.jsx
+++ b/frontend/src/pages/settings/Profile.jsx
@@ -22,8 +22,8 @@ import queryClient from "@queries/queryClient"
 import { useTranslation } from "react-i18next"
 import { toast } from "react-toastify"
 
-const Account = () => {
-    const { t } = useTranslation("settings", { keyPrefix: "account" })
+const Profile = () => {
+    const { t } = useTranslation("settings", { keyPrefix: "profile" })
     const theme = useTheme()
 
     const { isDesktop } = useScreenType()
@@ -51,10 +51,10 @@ const Account = () => {
             queryClient.invalidateQueries({
                 queryKey: ["users", user.username],
             })
-            toast.success(t("account_edited"))
+            toast.success(t("profile_edited"))
         },
         onError: () => {
-            toast.error(t("account_fail"))
+            toast.error(t("profile_fail"))
         },
     })
 
@@ -227,4 +227,4 @@ const ColorButton = styled.div`
     background-color: ${(p) => p.$color};
 `
 
-export default Account
+export default Profile

--- a/frontend/src/pages/settings/settings.jsx
+++ b/frontend/src/pages/settings/settings.jsx
@@ -1,4 +1,3 @@
-import Account from "./Account"
 import Appearance from "./Appearance"
 import Blocks from "./Blocks"
 import General from "./General"
@@ -6,11 +5,12 @@ import Info from "./Info"
 import LanguagesAndTime from "./LanguagesAndTime"
 import Notifications from "./Notifications"
 import Privacy from "./Privacy"
+import Profile from "./Profile"
 import Reactions from "./Reactions"
 import Security from "./Security"
 
 export {
-    Account,
+    Profile,
     General,
     Security,
     Privacy,

--- a/frontend/src/routers/settingsChildren.jsx
+++ b/frontend/src/routers/settingsChildren.jsx
@@ -1,7 +1,7 @@
 import { lazily } from "react-lazily"
 
 const {
-    Account,
+    Profile,
     General,
     Security,
     Privacy,
@@ -19,8 +19,8 @@ const settingsChildren = [
         element: null,
     },
     {
-        path: "account",
-        element: <Account />,
+        path: "profile",
+        element: <Profile />,
     },
     {
         path: "general",


### PR DESCRIPTION
- '계정'을 '프로필'로 개명했습니다.

| Before | After |
|---|---|
| <img width="182" alt="Screenshot 2025-02-23 at 23 01 03" src="https://github.com/user-attachments/assets/baf0bc19-0941-4056-af12-65c8a085ce89" /> | <img width="182" alt="Screenshot 2025-02-23 at 23 01 11" src="https://github.com/user-attachments/assets/814b5a5f-3242-4c9e-b5aa-c2578191180b" /> |

- '차단'의 아이콘을 '보안'과 겹치는 `shield`에서 `slash`로 변경했습니다. _(보안이 나중에 생긴거지만...)_

| Before | After |
|---|---|
| <img width="109" alt="Screenshot 2025-02-23 at 22 59 06" src="https://github.com/user-attachments/assets/bb228169-4b79-47d6-8a85-ef5caca1502c" /> | <img width="109" alt="Screenshot 2025-02-23 at 22 58 54" src="https://github.com/user-attachments/assets/54d6ee70-9ede-407b-ba80-a370af6b256b" /> |

- `Select`와 `Switch`에 `cursor: pointer` 속성을 추가해 커서가 포인터로 표시되도록 수정했습니다.
- '보안>암호 변경'의 번역을 `profile`에서 `security` 아래로 옮겼습니다. (암호 변경이 원래 계정에 있었음)