### PR TITLE
Palette 타입화 및 getPaletteColor로의 개명

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -110,7 +110,7 @@
         "name_required": "A name is required.",
         "color": {
             "title": "Color Settings",
-            "theme1": "Basic",
+            "palette1": "Basic",
             "red": "red",
             "red_orange": "red orange",
             "orange": "orange",

--- a/frontend/public/locales/ko/translation.json
+++ b/frontend/public/locales/ko/translation.json
@@ -110,7 +110,7 @@
         "name_required": "이름을 지어주세요.",
         "color": {
             "title": "색깔 설정",
-            "theme1": "기본",
+            "palette1": "기본",
             "red": "빨간색",
             "red_orange": "레드오렌지",
             "orange": "주황색",

--- a/frontend/src/@types/styled.d.ts
+++ b/frontend/src/@types/styled.d.ts
@@ -1,8 +1,10 @@
 import "styled-components"
 
 declare module "styled-components" {
+    export type LightDark = "light" | "dark"
+
     export interface DefaultTheme {
-        type: "light" | "dark"
+        type: LightDark
         primaryColors: {
             text: string
             primary: string
@@ -68,6 +70,6 @@ declare module "styled-components" {
             activatedColor: string
             activatedBackgroundColor: string
         }
-        toastTheme: "light" | "dark"
+        toastTheme: LightDark
     }
 }

--- a/frontend/src/assets/palettes.ts
+++ b/frontend/src/assets/palettes.ts
@@ -1,5 +1,26 @@
+import type { LightDark } from "styled-components"
+
+export type PaletteColorName =
+    | "grey"
+    | "red"
+    | "red_orange"
+    | "orange"
+    | "yellow"
+    | "bright_sky_blue"
+    | "blue"
+    | "magenta"
+    | "violet"
+    | "pink"
+    | "hot_pink"
+    | "light_green"
+    | "mint"
+    | "olive"
+    | "dark_violet"
+    | "deep_blue"
+    | "deep_indigo"
+
 export const palettes = {
-    theme1: [
+    palette1: [
         "red",
         "red_orange",
         "orange",
@@ -16,10 +37,12 @@ export const palettes = {
         "dark_violet",
         "deep_blue",
         "deep_indigo",
-    ],
+    ] as PaletteColorName[],
 }
 
-const light = {
+type Palette = Record<PaletteColorName, string>
+
+const light: Palette = {
     grey: "#CCCCCC",
     red: "#FF3B3B",
     red_orange: "#F05A29",
@@ -39,7 +62,7 @@ const light = {
     deep_indigo: "#0C0CB2",
 }
 
-const dark = {
+const dark: Palette = {
     grey: "#858585",
     red: "#FF3B3B",
     red_orange: "#F05A29",
@@ -64,6 +87,9 @@ const themes = {
     dark: dark,
 }
 
-export const getProjectColor = (theme, color) => {
-    return themes[theme][color]
+export const getPaletteColor = (
+    theme: LightDark,
+    colorName: PaletteColorName,
+) => {
+    return themes[theme][colorName]
 }

--- a/frontend/src/assets/themes.ts
+++ b/frontend/src/assets/themes.ts
@@ -1,4 +1,4 @@
-import type { DefaultTheme } from "styled-components"
+import type { DefaultTheme, LightDark } from "styled-components"
 
 export type State = keyof DefaultTheme["primaryColors"]
 
@@ -166,7 +166,7 @@ const dark: DefaultTheme = {
     toastTheme: "dark",
 }
 
-export default { system: null, light: light, dark: dark } as Record<
-    "system" | "light" | "dark",
+export default { system: null, light, dark } as Record<
+    "system" | LightDark,
     DefaultTheme | null
 >

--- a/frontend/src/components/home/VGraph.jsx
+++ b/frontend/src/components/home/VGraph.jsx
@@ -1,6 +1,6 @@
 import styled, { useTheme } from "styled-components"
 
-import { getProjectColor } from "@components/project/common/palettes"
+import { getPaletteColor } from "@assets/palettes"
 
 const VGraph = ({ items, countAll, loading }) => {
     const theme = useTheme()
@@ -25,7 +25,7 @@ const VGraph = ({ items, countAll, loading }) => {
                     <Item
                         key={item.name}
                         $width={(item.count / countAll) * 100}
-                        $color={getProjectColor(theme.type, item.color)}
+                        $color={getPaletteColor(theme.type, item.color)}
                         draggable="false"
                     />
                 ))}
@@ -34,7 +34,7 @@ const VGraph = ({ items, countAll, loading }) => {
                 {items?.map((item) => (
                     <Category key={item.name}>
                         <CategoryCircle
-                            $color={getProjectColor(theme.type, item.color)}
+                            $color={getPaletteColor(theme.type, item.color)}
                             draggable="false"
                         />{" "}
                         {item.name}

--- a/frontend/src/components/intro/DemoCheer.jsx
+++ b/frontend/src/components/intro/DemoCheer.jsx
@@ -5,13 +5,14 @@ import styled, { useTheme } from "styled-components"
 
 import SubSection from "@components/intro/SubSection"
 import { today } from "@components/intro/todays"
-import { getProjectColor } from "@components/project/common/palettes"
 import { Modal as EmojiModalWindow } from "@components/social/interaction/reaction/EmojiModal"
 import EmojiPickerButton from "@components/social/interaction/reaction/EmojiPickerButton"
 import ReactionButton from "@components/social/interaction/reaction/ReactionButton"
 import TaskFrame from "@components/tasks/TaskFrame"
 
 import { getEmojis } from "@api/social.api"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import { useTranslation } from "react-i18next"
 
@@ -107,7 +108,7 @@ const DemoCheer = () => {
 const makeTask = (t, theme) => ({
     name: t("task_name"),
     completed_at: today,
-    color: getProjectColor(theme.type, "green"),
+    color: getPaletteColor(theme.type, "green"),
 })
 
 const CustomizedPickerButton = styled(EmojiPickerButton)`

--- a/frontend/src/components/project/ProjectName.jsx
+++ b/frontend/src/components/project/ProjectName.jsx
@@ -2,9 +2,9 @@ import { Link } from "react-router-dom"
 
 import styled, { useTheme } from "styled-components"
 
-import { getProjectColor } from "@components/project/common/palettes"
-
 import { ifMobile } from "@utils/useScreenType"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import FeatherIcon from "feather-icons-react"
 import { useTranslation } from "react-i18next"
@@ -28,7 +28,7 @@ const ProjectName = ({ project, demo = false }) => {
             <FlexBox>
                 <FeatherIcon
                     icon="circle"
-                    fill={getProjectColor(theme.type, project.color)}
+                    fill={getPaletteColor(theme.type, project.color)}
                 />
                 {nameParts}
                 <TypeText>

--- a/frontend/src/components/project/common/Progress.jsx
+++ b/frontend/src/components/project/common/Progress.jsx
@@ -1,7 +1,8 @@
 import styled, { useTheme } from "styled-components"
 
 import BarChart from "@components/project/common/BarChart"
-import { getProjectColor } from "@components/project/common/palettes"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import { useTranslation } from "react-i18next"
 
@@ -31,7 +32,7 @@ const Progress = ({ project, drawers }) => {
             <FlexBox>
                 <BarChart
                     isCompleted={isCompleted()}
-                    color={getProjectColor(theme.type, project.color)}
+                    color={getPaletteColor(theme.type, project.color)}
                     drawers={drawers}
                     projectTaskCount={projectTaskCount}
                 />

--- a/frontend/src/components/project/edit/Color.jsx
+++ b/frontend/src/components/project/edit/Color.jsx
@@ -4,7 +4,8 @@ import styled, { css, useTheme } from "styled-components"
 
 import { useModalWindowCloseContext } from "@components/common/ModalWindow"
 import Detail from "@components/project/common/Detail"
-import { getProjectColor, palettes } from "@components/project/common/palettes"
+
+import { getPaletteColor, palettes } from "@assets/palettes"
 
 import FeatherIcon from "feather-icons-react"
 import { useTranslation } from "react-i18next"
@@ -15,7 +16,7 @@ const Color = ({ setColor }) => {
     })
     const theme = useTheme()
 
-    const [activeTab, setActiveTab] = useState("theme1")
+    const [activeTab, setActiveTab] = useState("palette1")
 
     const { closeModal } = useModalWindowCloseContext()
 
@@ -26,26 +27,26 @@ const Color = ({ setColor }) => {
         }
     }
 
-    const themes = [{ id: "theme1", themeName: t("theme1") }]
+    const paletteChoices = [{ id: "palette1", themeName: t("palette1") }]
 
     return (
         <Detail title={t("title")} onClose={closeModal}>
             <TabBox>
-                {themes.map((theme) => (
+                {paletteChoices.map((choice) => (
                     <TabButton
-                        key={theme.themeName}
-                        $isActive={activeTab === theme.id}
-                        onClick={() => setActiveTab(theme.id)}>
-                        {theme.themeName}
+                        key={choice.themeName}
+                        $isActive={activeTab === choice.id}
+                        onClick={() => setActiveTab(choice.id)}>
+                        {choice.themeName}
                     </TabButton>
                 ))}
             </TabBox>
-            {palettes[activeTab]?.map((palette) => (
-                <ItemBlock key={palette}>
+            {palettes[activeTab]?.map((colorName) => (
+                <ItemBlock key={colorName}>
                     <FeatherIcon
                         icon="circle"
-                        fill={getProjectColor(theme.type, palette)}
-                        onClick={changeColor(palette)}
+                        fill={getPaletteColor(theme.type, colorName)}
+                        onClick={changeColor(colorName)}
                     />
                 </ItemBlock>
             ))}

--- a/frontend/src/components/project/edit/ProjectEdit.jsx
+++ b/frontend/src/components/project/edit/ProjectEdit.jsx
@@ -5,7 +5,6 @@ import { useTheme } from "styled-components"
 
 import Button, { ButtonGroup } from "@components/common/Button"
 import { useModalWindowCloseContext } from "@components/common/ModalWindow"
-import { getProjectColor } from "@components/project/common/palettes"
 import Color from "@components/project/edit/Color"
 import EditBox from "@components/project/edit/EditBox"
 import Middle from "@components/project/edit/Middle"
@@ -18,6 +17,8 @@ import { patchProject, postProject } from "@api/projects.api"
 import useScreenType from "@utils/useScreenType"
 
 import queryClient from "@queries/queryClient"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import { useTranslation } from "react-i18next"
 import { toast } from "react-toastify"
@@ -139,7 +140,7 @@ const makeItems = (t, theme, project, setFunc) => [
     {
         id: "color",
         icon: "circle",
-        color: getProjectColor(theme.type, project.color),
+        color: getPaletteColor(theme.type, project.color),
         display: t("color." + project.color),
         component: <Color setColor={setFunc} />,
     },

--- a/frontend/src/components/project/taskDetails/DrawerFolder.jsx
+++ b/frontend/src/components/project/taskDetails/DrawerFolder.jsx
@@ -2,9 +2,9 @@ import { useState } from "react"
 
 import styled, { useTheme } from "styled-components"
 
-import { getProjectColor } from "@components/project/common/palettes"
-
 import { ifMobile } from "@utils/useScreenType"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import FeatherIcon from "feather-icons-react"
 
@@ -25,7 +25,7 @@ const DrawerFolder = ({ project, changeDrawer }) => {
                           )
                         : () => setCollapsed((prev) => !prev)
                 }>
-                <Circle $color={getProjectColor(theme.type, project.color)} />
+                <Circle $color={getPaletteColor(theme.type, project.color)} />
                 <ItemText $is_project={true}>{project.name}</ItemText>
             </ItemBox>
             {project.type === "inbox" || collapsed

--- a/frontend/src/components/search/SearchResults.jsx
+++ b/frontend/src/components/search/SearchResults.jsx
@@ -4,8 +4,9 @@ import { useNavigate } from "react-router-dom"
 import styled, { useTheme } from "styled-components"
 
 import DrawerBox, { DrawerName } from "@components/drawers/DrawerBox"
-import { getProjectColor } from "@components/project/common/palettes"
 import TaskFrame from "@components/tasks/TaskFrame"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import { ImpressionArea } from "@toss/impression-area"
 import { useTranslation } from "react-i18next"
@@ -34,7 +35,7 @@ const SearchResults = ({ resultPage, fetchNextResultPage }) => {
 
             {resultPage?.pages.map((page) =>
                 page.results.map((task) => {
-                    const color = getProjectColor(
+                    const color = getPaletteColor(
                         theme.type,
                         task.project_color,
                     )

--- a/frontend/src/components/sidebar/Middle.jsx
+++ b/frontend/src/components/sidebar/Middle.jsx
@@ -3,13 +3,13 @@ import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import styled, { css, useTheme } from "styled-components"
 
-import { getProjectColor } from "@components/project/common/palettes"
 import { useSidebarContext } from "@components/sidebar/SidebarContext"
 import SidebarLink from "@components/sidebar/SidebarLink"
 
 import { getProjectList } from "@api/projects.api"
 
 import { cubicBeizer } from "@assets/keyframes"
+import { getPaletteColor } from "@assets/palettes"
 import { skeletonCSS } from "@assets/skeleton"
 
 import FeatherIcon from "feather-icons-react"
@@ -87,7 +87,7 @@ const Middle = () => {
                         <ProjectItemBox $collapsed={isCollapsed}>
                             <FeatherIcon
                                 icon="circle"
-                                fill={getProjectColor(
+                                fill={getPaletteColor(
                                     theme.type,
                                     project.color,
                                 )}

--- a/frontend/src/components/social/logDetails/LogDetails.jsx
+++ b/frontend/src/components/social/logDetails/LogDetails.jsx
@@ -4,7 +4,6 @@ import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query"
 import styled, { useTheme } from "styled-components"
 
 import DrawerBox, { DrawerName } from "@components/drawers/DrawerBox"
-import { getProjectColor } from "@components/project/common/palettes"
 import { SkeletonProjectPage } from "@components/project/skeletons/SkeletonProjectPage"
 import InteractionBox from "@components/social/interaction/InteractionBox"
 import Quote from "@components/social/logDetails/Quote"
@@ -18,6 +17,8 @@ import { getDailyLogDetails, getQuote, postQuote } from "@api/social.api"
 import { ifMobile } from "@utils/useScreenType"
 
 import queryClient from "@queries/queryClient"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import { ImpressionArea } from "@toss/impression-area"
 import { useTranslation } from "react-i18next"
@@ -113,7 +114,7 @@ const LogDetails = ({ pageType = "following", username, selectedDate }) => {
 
                 {logDetailsPage?.pages.map((group) =>
                     group.results.map((task, index, array) => {
-                        const color = getProjectColor(
+                        const color = getPaletteColor(
                             theme.type,
                             task.project_color,
                         )

--- a/frontend/src/components/social/logsPreview/LogPreviewBox.jsx
+++ b/frontend/src/components/social/logsPreview/LogPreviewBox.jsx
@@ -1,6 +1,5 @@
 import styled, { useTheme } from "styled-components"
 
-import { getProjectColor } from "@components/project/common/palettes"
 import SimpleProfile from "@components/social/common/SimpleProfile"
 import LogDetails from "@components/social/logDetails/LogDetails"
 
@@ -8,6 +7,8 @@ import { getCurrentUsername } from "@api/client"
 
 import { useClientLocale } from "@utils/clientSettings"
 import useScreenType, { ifMobile } from "@utils/useScreenType"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import { DateTime } from "luxon"
 import { useTranslation } from "react-i18next"
@@ -48,7 +49,7 @@ const LogPreviewBox = ({
         return log.recent_task
             ? log.recent_task.is_read
                 ? theme.grey
-                : getProjectColor(theme.type, log.recent_task.project_color)
+                : getPaletteColor(theme.type, log.recent_task.project_color)
             : null
     }
 

--- a/frontend/src/components/today/ImportantTasks.jsx
+++ b/frontend/src/components/today/ImportantTasks.jsx
@@ -6,7 +6,6 @@ import styled, { css, useTheme } from "styled-components"
 
 import CollapseButton from "@components/common/CollapseButton"
 import { ErrorBox } from "@components/errors/ErrorProjectPage"
-import { getProjectColor } from "@components/project/common/palettes"
 import { SkeletonDueTasks } from "@components/project/skeletons/SkeletonTodayPage"
 import Task from "@components/tasks/Task"
 
@@ -22,6 +21,8 @@ import { getPageFromURL } from "@utils/pagination"
 import { ifMobile } from "@utils/useScreenType"
 
 import queryClient from "@queries/queryClient"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import FeatherIcon from "feather-icons-react"
 import { DateTime } from "luxon"
@@ -166,7 +167,7 @@ const ImportantTasks = () => {
                                     <ImportantTaskBox key={task.id}>
                                         <Task
                                             task={task}
-                                            color={getProjectColor(
+                                            color={getPaletteColor(
                                                 theme.type,
                                                 task.project_color,
                                             )}

--- a/frontend/src/components/today/TodayAssignmentTasks.jsx
+++ b/frontend/src/components/today/TodayAssignmentTasks.jsx
@@ -5,7 +5,6 @@ import styled, { useTheme } from "styled-components"
 
 import Button from "@components/common/Button"
 import { ErrorBox } from "@components/errors/ErrorProjectPage"
-import { getProjectColor } from "@components/project/common/palettes"
 import { SkeletonDueTasks } from "@components/project/skeletons/SkeletonTodayPage"
 import Task from "@components/tasks/Task"
 
@@ -13,6 +12,8 @@ import { getTasksAssignedToday } from "@api/today.api"
 
 import { useClientTimezone } from "@utils/clientSettings"
 import { getPageFromURL } from "@utils/pagination"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import { DateTime } from "luxon"
 import { useTranslation } from "react-i18next"
@@ -66,7 +67,7 @@ const TodayAssignmentTasks = () => {
                             <Task
                                 key={task.id}
                                 task={task}
-                                color={getProjectColor(
+                                color={getPaletteColor(
                                     theme.type,
                                     task.project_color,
                                 )}

--- a/frontend/src/components/users/ProjectList.jsx
+++ b/frontend/src/components/users/ProjectList.jsx
@@ -2,11 +2,11 @@ import { Link } from "react-router-dom"
 
 import styled, { css, useTheme } from "styled-components"
 
-import { getProjectColor } from "@components/project/common/palettes"
 import { Section, SectionTitle } from "@components/users/Section"
 
 import { ifMobile } from "@utils/useScreenType"
 
+import { getPaletteColor } from "@assets/palettes"
 import { skeletonCSS } from "@assets/skeleton"
 
 import { useTranslation } from "react-i18next"
@@ -27,7 +27,7 @@ const ProjectList = ({ projects, isMine, isPending }) => {
                     const projectCompo = (
                         <Project key={project.id}>
                             <Circle
-                                $color={getProjectColor(
+                                $color={getPaletteColor(
                                     theme.type,
                                     project.color,
                                 )}

--- a/frontend/src/components/users/UserProfileHeader.jsx
+++ b/frontend/src/components/users/UserProfileHeader.jsx
@@ -3,13 +3,13 @@ import { Link } from "react-router-dom"
 import styled, { css, useTheme } from "styled-components"
 
 import Button from "@components/common/Button"
-import { getProjectColor } from "@components/project/common/palettes"
 import FollowButton from "@components/users/FollowButton"
 import FollowsCount from "@components/users/FollowsCount"
 
 import { ifMobile, ifTablet } from "@utils/useScreenType"
 
 import { cubicBeizer } from "@assets/keyframes"
+import { getPaletteColor } from "@assets/palettes"
 import { skeletonBreathingCSS } from "@assets/skeleton"
 
 import { useTranslation } from "react-i18next"
@@ -29,7 +29,7 @@ const UserProfileHeader = ({ user, followingYou, isMine, isPending }) => {
     return (
         <>
             <Banner
-                $headerColor={getProjectColor(theme.type, user?.header_color)}>
+                $headerColor={getPaletteColor(theme.type, user?.header_color)}>
                 {followingYou?.status === "accepted" ? (
                     <FollowsYou>{t("follows_you")}</FollowsYou>
                 ) : (

--- a/frontend/src/pages/ProjectPage.jsx
+++ b/frontend/src/pages/ProjectPage.jsx
@@ -13,7 +13,6 @@ import Drawer from "@components/drawers/Drawer"
 import { ErrorBox } from "@components/errors/ErrorProjectPage"
 import PrivacyIcon from "@components/project/common/PrivacyIcon"
 import Progress from "@components/project/common/Progress"
-import { getProjectColor } from "@components/project/common/palettes"
 import DrawerEdit from "@components/project/edit/DrawerEdit"
 import ProjectEdit from "@components/project/edit/ProjectEdit"
 import { SkeletonProjectPage } from "@components/project/skeletons/SkeletonProjectPage"
@@ -27,6 +26,8 @@ import handleToggleContextMenu from "@utils/handleToggleContextMenu"
 import { ifMobile } from "@utils/useScreenType"
 
 import queryClient from "@queries/queryClient"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import FeatherIcon from "feather-icons-react"
 import { useTranslation } from "react-i18next"
@@ -149,7 +150,7 @@ const ProjectPage = () => {
         )
     }
 
-    const color = getProjectColor(theme.type, project?.color)
+    const color = getPaletteColor(theme.type, project?.color)
 
     return (
         <>
@@ -158,7 +159,7 @@ const ProjectPage = () => {
                     <PageTitle $color={color}>{project.name}</PageTitle>
                     <PrivacyIcon
                         privacy={project.privacy}
-                        color={getProjectColor(theme.type, project.color)}
+                        color={getPaletteColor(theme.type, project.color)}
                         isProject
                     />
                 </PageTitleBox>

--- a/frontend/src/pages/settings/Profile.jsx
+++ b/frontend/src/pages/settings/Profile.jsx
@@ -6,7 +6,6 @@ import styled, { useTheme } from "styled-components"
 import Button, { ButtonGroup } from "@components/common/Button"
 import { LoaderCircleFull } from "@components/common/LoaderCircle"
 import ModalWindow from "@components/common/ModalWindow"
-import { getProjectColor } from "@components/project/common/palettes"
 import Color from "@components/project/edit/Color"
 import Error from "@components/settings/Error"
 import ProfileImg from "@components/settings/ProfileImg"
@@ -18,6 +17,8 @@ import { getMe, patchUser } from "@api/users.api"
 import useScreenType, { ifMobile } from "@utils/useScreenType"
 
 import queryClient from "@queries/queryClient"
+
+import { getPaletteColor } from "@assets/palettes"
 
 import { useTranslation } from "react-i18next"
 import { toast } from "react-toastify"
@@ -128,7 +129,7 @@ const Profile = () => {
                     <Value>
                         <ColorButton
                             onClick={onClickOpenPalette}
-                            $color={getProjectColor(
+                            $color={getPaletteColor(
                                 theme.type,
                                 headerColor.color,
                             )}


### PR DESCRIPTION
- 파일 이동: `frontend/project/common/palette.js` -> `frontend/assets/palette.ts`
- 함수 개명: 색상이 프로젝트 바깥에서도 쓰이므로 `getProjectColor` -> `getPaletteColor`
- 속성 개명: 라이트/다크 테마와의 혼동 방지를 위해 `theme1`를 `palette1`으로 개명
- 타입 추가: `styled-components`에 `LightDark` 타입 추가(`"light"` 혹은 `"dark"`만 허용)
- `Palette` 타입화

<img width="506" alt="Screenshot 2025-02-24 at 15 02 14" src="https://github.com/user-attachments/assets/f6626028-ad7e-41eb-bb49-40c2045d08ad" />

- `getPaletteColor`에는 변수값을 넘기는 경우가 많으므로 자동완성이 큰 도움은 되지 않겠지만, 타입스크립트 이주로의 포석으로 이해하시면 됩니다.