### PR TITLE
dependabot PR 그룹화 설정

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -45,6 +45,9 @@ updates:
       - dependency-name: "django"
         versions: 
           - ">=5.0.0"
+      - dependency-name: "django-stubs*"
+        versions: 
+          - ">=5.0.0"
   - package-ecosystem: "docker"
     directories:
       - "/frontend"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "react"
         versions: 
@@ -21,10 +21,30 @@ updates:
       - dependency-name: "react-router-dom"
         versions: 
           - ">=7.0.0"
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates 
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      pip-minor-patch:
+        applies-to: version-updates 
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "django"
+        versions: 
+          - ">=5.0.0"
   - package-ecosystem: "docker"
     directories:
       - "/frontend"

--- a/.github/workflows/reviewer.yaml
+++ b/.github/workflows/reviewer.yaml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   assign-reviewer:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Run random-reviewer-discord
         uses: JedBeom/random-reviewer-discord@v0.2.1


### PR DESCRIPTION
- 모든 의존성 체크를 '주간'으로 변경했습니다. (UTC 기준 월요일 실행)
- npm과 pip의 마이너 및 패치 버전 업그레이드 PR끼리는 묶도록 설정했습니다. [참고한 글](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates) [공식 문서](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--)
- `django`의 5.0.0 이상 버전은 일단 무시하도록 설정했습니다.
- 액션을 실행한 주체가 dependabot일 경우 `reviewer.yaml`은 실행하지 않도록 설정했습니다.