### PR TITLE
pagination 함수 인자 타입에 URL 추가

### DIFF
--- a/frontend/src/utils/pagination.ts
+++ b/frontend/src/utils/pagination.ts
@@ -1,5 +1,5 @@
 export const getPageFromURL = (url: null | string | URL): null | string => {
-    if (url === null || url === "") {
+    if (!url) {
         return url
     }
 
@@ -9,7 +9,7 @@ export const getPageFromURL = (url: null | string | URL): null | string => {
 }
 
 export const getCursorFromURL = (url: null | string | URL): null | string => {
-    if (url === null || url === "") {
+    if (!url) {
         return url
     }
 

--- a/frontend/src/utils/pagination.ts
+++ b/frontend/src/utils/pagination.ts
@@ -1,27 +1,19 @@
-export const getPageFromURL = (url: null | string): null | string => {
-    if (!url) return null
-
-    let u: URL
-    if (typeof url === "string") {
-        u = new URL(url)
-    } else {
-        u = url
+export const getPageFromURL = (url: null | string | URL): null | string => {
+    if (url === null || url === "") {
+        return url
     }
 
+    const u = new URL(url)
     const page = u.searchParams.get("page")
     return page
 }
 
-export const getCursorFromURL = (url: null | string): null | string => {
-    if (!url) return null
-
-    let u: URL
-    if (typeof url === "string") {
-        u = new URL(url)
-    } else {
-        u = url
+export const getCursorFromURL = (url: null | string | URL): null | string => {
+    if (url === null || url === "") {
+        return url
     }
 
+    const u = new URL(url)
     const cursor = u.searchParams.get("cursor")
     return cursor
 }


### PR DESCRIPTION
#364 PR에서 함수들의 인자 타입에 `URL`을 포함하는 것을 잊어서... 추가 PR을 올립니다.

- `URL` 생성자가 `URL` 자신도 받기 때문에 `string | URL`인 인자를 그대로 생성자에 전달합니다.

(추가) JS 파일에서 url로 `undefined`를 전달할 가능성도 있기 때문에 조건문을 원복시켰습니다.