### PR TITLE
ImageCropper의 버튼 색상 수정

### DIFF
--- a/frontend/public/global.css
+++ b/frontend/public/global.css
@@ -214,11 +214,6 @@ body {
     vertical-align: auto;
 }
 
-.reactEasyCrop_Container {
-    position: fixed !important;
-    z-index: 999;
-}
-
 .Toastify__toast {
     line-height: 1.3 !important;
 }

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -35,8 +35,8 @@ export default function Button({
 }
 
 export const ButtonGroup = styled.div<{
-    $justifyContent: string
-    $margin: string
+    $justifyContent?: string
+    $margin?: string
 }>`
     display: flex;
     gap: 1em;

--- a/frontend/src/components/settings/ImageCropper.jsx
+++ b/frontend/src/components/settings/ImageCropper.jsx
@@ -40,7 +40,7 @@ const ImageCropper = ({
                 <Button form="outlined" state="danger" onClick={onClickCancel}>
                     {t("button_cancel")}
                 </Button>
-                <Button form="filled" state="danger" onClick={onClickOk}>
+                <Button form="filled" state="success" onClick={onClickOk}>
                     {t("button_apply")}
                 </Button>
             </StyledButtonGroup>

--- a/frontend/src/components/settings/ImageCropper.tsx
+++ b/frontend/src/components/settings/ImageCropper.tsx
@@ -5,23 +5,30 @@ import styled from "styled-components"
 import Button, { ButtonGroup } from "@components/common/Button"
 
 import { createPortal } from "react-dom"
-import Cropper from "react-easy-crop"
+import Cropper, { type Area } from "react-easy-crop"
 import { useTranslation } from "react-i18next"
 
-const el = document.querySelector("#confirmation")
+const el = document.querySelector("#confirmation")!
+
+type ImageCropperProp = {
+    file: string
+    setCroppedAreaPixels: (area: Area) => void
+    onClickOk: () => void
+    onClickCancel: () => void
+}
 
 const ImageCropper = ({
     file,
     setCroppedAreaPixels,
     onClickOk,
     onClickCancel,
-}) => {
+}: ImageCropperProp) => {
     const [crop, setCrop] = useState({ x: 0, y: 0 })
     const [zoom, setZoom] = useState(1)
 
     const { t } = useTranslation("settings", { keyPrefix: "profile" })
 
-    const onCropComplete = (croppedArea, croppedAreaPixels) => {
+    const onCropComplete = (_: Area, croppedAreaPixels: Area) => {
         setCroppedAreaPixels(croppedAreaPixels)
     }
 
@@ -35,6 +42,12 @@ const ImageCropper = ({
                 onCropChange={setCrop}
                 onCropComplete={onCropComplete}
                 onZoomChange={setZoom}
+                style={{
+                    containerStyle: {
+                        position: "fixed",
+                        zIndex: 999,
+                    },
+                }}
             />
             <StyledButtonGroup>
                 <Button form="outlined" state="danger" onClick={onClickCancel}>


### PR DESCRIPTION
#335 PR에서 `ImageCropper`의 버튼 색상을 잘못 옮겼던 것을 고쳤습니다.

| Before | After |
|---|---|
| <img width="345" alt="Screenshot 2025-02-27 at 17 38 23" src="https://github.com/user-attachments/assets/5fb61486-1402-44a0-b9fb-99a00c40003c" /> | <img width="345" alt="Screenshot 2025-02-27 at 17 38 01" src="https://github.com/user-attachments/assets/12393415-1e47-4a20-9780-77c1c6061874" /> |

- `ImageCropper`를 타입스크립트로 옮겼습니다.
- `ButtonGroup`의 prop들을 optional로 바꿨습니다.
- `global.css`에 있던 `ImageCropper` 스타일을 `Cropper`에 객체 형태로 넘기도록 수정했습니다.
  - `styled-components`를 사용하지 않는 이유는, `Cropper`에서 `className` prop이 없기 때문입니다.