### PR TITLE
모바일 화면에서 토스트가 띄워졌을 때 네비바가 눌리지 않는 문제 해결

### DIFF
--- a/frontend/public/global.css
+++ b/frontend/public/global.css
@@ -248,7 +248,7 @@ body {
         width: calc(100dvw - 2em) !important;
     }
 
-    .Toastify__toast--stacked[data-pos=bot].Toastify__toast--stacked:before {
+    .Toastify__toast--stacked[data-pos="bot"].Toastify__toast--stacked:before {
         bottom: calc(max(env(safe-area-inset-bottom), 10px) + 6.5em) !important;
     }
 

--- a/frontend/public/global.css
+++ b/frontend/public/global.css
@@ -248,6 +248,10 @@ body {
         width: calc(100dvw - 2em) !important;
     }
 
+    .Toastify__toast--stacked[data-pos=bot].Toastify__toast--stacked:before {
+        bottom: calc(max(env(safe-area-inset-bottom), 10px) + 6.5em) !important;
+    }
+
     .Toastify__close-button {
         margin: auto 10px;
     }

--- a/frontend/public/global.css
+++ b/frontend/public/global.css
@@ -253,7 +253,8 @@ body {
     }
 
     .Toastify__close-button {
-        margin: auto 10px;
+        margin-right: 10px;
+        top: unset;
     }
 }
 


### PR DESCRIPTION
토스트가 띄워졌을 때 네비바가 눌리지 않는 문제가 있어 수정했습니다.
아마 #331 PR에서 react-toastify v11로 업데이트했을 때부터 생긴 증상 같습니다.