### PR TITLE
window.Notification이 undefined일 때 AllowNotification을 표시하지 않도록 수정

### DIFF
--- a/frontend/src/components/home/AllowNotification.tsx
+++ b/frontend/src/components/home/AllowNotification.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next"
 const AllowNotification = () => {
     const { t } = useTranslation("home", { keyPrefix: "allow_notification" })
 
-    if (window.Notification.permission !== "default") {
+    if (!window.Notification || window.Notification.permission !== "default") {
         return null
     }
 


### PR DESCRIPTION
홈의 모듈 중 하나인 `AllowNotification`의 조건문에 `window.Notification`이 `undefined`일 때도 추가했습니다.

iOS Safari에서 앱을 홈 화면에 추가하지 않으면 `window.Notification`이 `undefined`입니다.