### PR TITLE
'설정>테마'에서 '시스템'이 없어졌던 문제 해결

### DIFF
--- a/frontend/src/components/settings/Select.jsx
+++ b/frontend/src/components/settings/Select.jsx
@@ -4,7 +4,12 @@ import styled from "styled-components"
 
 import { useClientSetting } from "@utils/clientSettings"
 
-const Select = ({ name, submit, choices, onlineSetting }) => {
+const Select = ({
+    name,
+    choices,
+    submit = () => {},
+    onlineSetting = undefined,
+}) => {
     const [clientSetting, setClientSetting] = useClientSetting()
     const [value, setValue] = useState(
         onlineSetting ? onlineSetting[name] : clientSetting[name],

--- a/frontend/src/components/settings/SettingSwitch.jsx
+++ b/frontend/src/components/settings/SettingSwitch.jsx
@@ -4,7 +4,11 @@ import Switch from "@components/common/Switch"
 
 import { useClientSetting } from "@utils/clientSettings"
 
-const SettingSwitch = ({ submit, name, onlineSetting }) => {
+const SettingSwitch = ({
+    name,
+    submit = () => {},
+    onlineSetting = undefined,
+}) => {
     const [clientSetting, setClientSetting] = useClientSetting()
     const [value, setValue] = useState(
         onlineSetting ? onlineSetting[name] : clientSetting[name],

--- a/frontend/src/pages/settings/Appearance.tsx
+++ b/frontend/src/pages/settings/Appearance.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from "react"
 
+import type { LightDark } from "styled-components"
+
 import Section, { Description, Name, Value } from "@components/settings/Section"
 import Select from "@components/settings/Select"
 import Switch from "@components/settings/SettingSwitch"
 
-import themes from "@assets/themes"
-
+import { TFunction } from "i18next"
 import { useTranslation } from "react-i18next"
 
 const Appearance = () => {
@@ -41,17 +42,16 @@ const Appearance = () => {
     )
 }
 
-const makeThemeChoices = (t) => {
-    const keys = Object.keys(themes)
-    const prefix = "theme.values."
+const makeThemeChoices = (t: TFunction<"settings", "appearance">) => {
+    const keys: ("system" | LightDark)[] = ["system", "light", "dark"]
 
     return keys.map((value) => ({
-        display: t(prefix + value),
+        display: t(`theme.values.${value}`),
         value,
     }))
 }
 
-const makeWidthChoices = (t) => [
+const makeWidthChoices = (t: TFunction<"settings", "appearance">) => [
     {
         display: t("main_width.values.narrow"),
         value: "7rem",


### PR DESCRIPTION
- `frontend/src/pages/settings/Appearance.tsx`: #393 PR 이후 **설정>테마**에서 '시스템'을 선택할 수 없던 문제를 수정했습니다.
- `frontend/src/components/settings/Select.jsx` & `frontend/src/components/settings/SettingSwitch.jsx`: 온라인에서만 사용되는 prop을 optional화 했습니다. 추후 타입화하겠습니다.