### PR TITLE
모든 URL 뒷부분에 슬래시 추가

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,4 +26,4 @@ RUN cp -r /usr/local/lib/python3.13/site-packages/rest_framework/static/ /static
 WORKDIR /backend
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=2s --retries=5 CMD \
-    wget --server-response http://127.0.0.1:8000/health/ok -O /dev/null
+    wget --server-response http://127.0.0.1:8000/health/ok/ -O /dev/null

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("ok", views.get_healthcheck),
+    path("ok/", views.get_healthcheck),
 ]

--- a/backend/django_peak/settings.py
+++ b/backend/django_peak/settings.py
@@ -119,6 +119,8 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "django_peak.wsgi.application"
 
+APPEND_SLASH = False
+
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases

--- a/backend/drawers/urls.py
+++ b/backend/drawers/urls.py
@@ -6,7 +6,7 @@ from . import views
 
 urlpatterns = [
     path("", views.DrawerList.as_view()),
-    path("<str:id>", views.DrawerDetail.as_view()),
+    path("<str:id>/", views.DrawerDetail.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/backend/notifications/urls.py
+++ b/backend/notifications/urls.py
@@ -6,11 +6,11 @@ from . import views
 
 urlpatterns = [
     path("", views.NotificationList.as_view()),
-    path("subscribe", views.WebPushSubscriptionCreate.as_view()),
-    path("subscribe/<str:id>", views.WebPushSubscriptionDetail.as_view()),
-    path("<str:id>", views.NotificationDetail.as_view()),
+    path("subscribe/", views.WebPushSubscriptionCreate.as_view()),
+    path("subscribe/<str:id>/", views.WebPushSubscriptionDetail.as_view()),
+    path("<str:id>/", views.NotificationDetail.as_view()),
     path("reminders/", views.ReminderList.as_view()),
-    path("reminders/<str:id>", views.ReminderDetail.as_view()),
+    path("reminders/<str:id>/", views.ReminderDetail.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/backend/projects/urls.py
+++ b/backend/projects/urls.py
@@ -6,7 +6,7 @@ from . import views
 
 urlpatterns = [
     path("", views.ProjectList.as_view()),
-    path("<str:id>", views.ProjectDetail.as_view()),
+    path("<str:id>/", views.ProjectDetail.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/backend/tasks/urls.py
+++ b/backend/tasks/urls.py
@@ -6,7 +6,7 @@ from . import views
 
 urlpatterns = [
     path("", views.TaskList.as_view()),
-    path("<str:id>", views.TaskDetail.as_view()),
+    path("<str:id>/", views.TaskDetail.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -72,7 +72,7 @@ class TaskList(mixins.ListModelMixin, mixins.CreateModelMixin, generics.GenericA
         ]
         ordering = self.request.GET.get("ordering", None)
 
-        if ordering.lstrip("-") in ordering_fields:
+        if ordering is not None and ordering.lstrip("-") in ordering_fields:
             normalize_drawer_order(queryset, ordering)
 
         return queryset

--- a/backend/today/urls.py
+++ b/backend/today/urls.py
@@ -5,11 +5,11 @@ from rest_framework.urlpatterns import format_suffix_patterns
 from . import views
 
 urlpatterns = [
-    path("assigned", views.TaskTodayAssignedList.as_view()),
-    path("todayDue", views.TodayDueTaskList.as_view()),
-    path("overDue", views.OverDueTaskList.as_view()),
-    path("pastAssigned", views.PastAssignedTaskList.as_view()),
-    path("assigned/grouped", views.TaskTodayAssignedGrouped.as_view()),
+    path("assigned/", views.TaskTodayAssignedList.as_view()),
+    path("assigned/grouped/", views.TaskTodayAssignedGrouped.as_view()),
+    path("todayDue/", views.TodayDueTaskList.as_view()),
+    path("overDue/", views.OverDueTaskList.as_view()),
+    path("pastAssigned/", views.PastAssignedTaskList.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/frontend/src/api/announcements.api.js
+++ b/frontend/src/api/announcements.api.js
@@ -5,7 +5,7 @@ export const getAnnouncements = async (
     pinned_only = false,
     page = "",
 ) => {
-    const res = await client.get(`announcements`, {
+    const res = await client.get(`announcements/`, {
         params: { lang, page, pinned_only },
     })
     return res.data

--- a/frontend/src/api/drawers.api.js
+++ b/frontend/src/api/drawers.api.js
@@ -1,14 +1,14 @@
 import client from "@api/client"
 
 export const getDrawersByProject = async (projectID, ordering) => {
-    const res = await client.get(
-        `drawers?project=${projectID}&ordering=${ordering}`,
-    )
+    const res = await client.get(`drawers/`, {
+        params: { project: projectID, ordering: ordering },
+    })
     return res.data.results
 }
 
 export const getDrawer = async (id) => {
-    const res = await client.get(`drawers/${id}`)
+    const res = await client.get(`drawers/${id}/`)
     return res.data
 }
 
@@ -18,11 +18,11 @@ export const postDrawer = async (drawer) => {
 }
 
 export const patchDrawer = async (id, edit) => {
-    const res = await client.patch(`drawers/${id}`, edit)
+    const res = await client.patch(`drawers/${id}/`, edit)
     return res.data
 }
 
 export const deleteDrawer = async (id) => {
-    const res = await client.delete(`drawers/${id}`)
+    const res = await client.delete(`drawers/${id}/`)
     return res.data
 }

--- a/frontend/src/api/notifications.api.js
+++ b/frontend/src/api/notifications.api.js
@@ -7,7 +7,7 @@ import {
 import getDeviceType from "@utils/getDeviceType"
 
 export const getReminder = async (id) => {
-    const res = await client.get(`notifications/reminders/${id}`)
+    const res = await client.get(`notifications/reminders/${id}/`)
     return res.data
 }
 
@@ -17,12 +17,12 @@ export const postReminder = async (reminders) => {
 }
 
 export const patchReminder = async (id, edit) => {
-    const res = await client.patch(`notifications/reminders/${id}`, edit)
+    const res = await client.patch(`notifications/reminders/${id}/`, edit)
     return res.data
 }
 
 export const deleteReminder = async (id) => {
-    const res = await client.delete(`notifications/reminders/${id}`)
+    const res = await client.delete(`notifications/reminders/${id}/`)
     return res.data
 }
 
@@ -31,23 +31,23 @@ export const getNotifications = async (query) => {
     const cursor = query.pageParam
     const types = params.types.types.join("|")
 
-    const res = await client.get(
-        `notifications/?types=${types}&cursor=${cursor}`,
-    )
+    const res = await client.get(`notifications/`, {
+        params: { types, cursor },
+    })
     return res.data
 }
 
 export const getNotification = async (id) => {
-    const res = await client.get(`notifications/${id}`)
+    const res = await client.get(`notifications/${id}/`)
     return res.data
 }
 
 export const deleteNotification = async (id) => {
-    return client.delete(`notifications/${id}`)
+    return client.delete(`notifications/${id}/`)
 }
 
 export const getSubscription = async (id) => {
-    const res = await client.get(`notifications/subscribe/${id}`)
+    const res = await client.get(`notifications/subscribe/${id}/`)
     return res.data
 }
 
@@ -64,12 +64,12 @@ export const postSubscription = async (subscription) => {
         user_agent: navigator.userAgent,
     }
 
-    const res = await client.post(`notifications/subscribe`, data)
+    const res = await client.post(`notifications/subscribe/`, data)
     return res.data
 }
 
 export const patchSubscription = async (id, data) => {
-    const res = await client.patch(`notifications/subscribe/${id}`, data)
+    const res = await client.patch(`notifications/subscribe/${id}/`, data)
     return res.data
 }
 
@@ -84,6 +84,6 @@ export const deleteSubscription = async (id) => {
 
     setClientSettingsByName("push_notification_subscription", null)
 
-    const res = await client.delete(`notifications/subscribe/${id}`)
+    const res = await client.delete(`notifications/subscribe/${id}/`)
     return res.status
 }

--- a/frontend/src/api/projects.api.js
+++ b/frontend/src/api/projects.api.js
@@ -11,7 +11,7 @@ export const getProjectListByUser = async (username) => {
 }
 
 export const getProject = async (id) => {
-    const res = await client.get(`projects/${id}`)
+    const res = await client.get(`projects/${id}/`)
     return res.data
 }
 
@@ -21,11 +21,11 @@ export const postProject = async (project) => {
 }
 
 export const patchProject = async (id, edit) => {
-    const res = await client.patch(`projects/${id}`, edit)
+    const res = await client.patch(`projects/${id}/`, edit)
     return res.data
 }
 
 export const deleteProject = async (id) => {
-    const res = await client.delete(`projects/${id}`)
+    const res = await client.delete(`projects/${id}/`)
     return res.data
 }

--- a/frontend/src/api/social.api.js
+++ b/frontend/src/api/social.api.js
@@ -105,21 +105,22 @@ export const postQuote = async (date, quote) => {
 
 export const getDailyLogDetails = async (username, day, cursor) => {
     const res = await client.get(
-        `social/daily/log/details/@${username}/${day}/?cursor=${cursor}`,
+        `social/daily/log/details/@${username}/${day}/`,
+        { params: { cursor } },
     )
 
     return res.data
 }
 
 export const getExploreRecommend = async (cursor) => {
-    const res = await client.get(`social/explore/?cursor=${cursor}`)
+    const res = await client.get(`social/explore/`, { params: { cursor } })
 
     return res.data
 }
 
 export const getExploreFound = async (query, cursor) => {
     const params = new URLSearchParams({ query: query, cursor: cursor })
-    const res = await client.get(`social/explore/search/?${params.toString()}`)
+    const res = await client.get(`social/explore/search/`, { params })
     return res.data
 }
 
@@ -150,7 +151,8 @@ export const deleteReaction = async (parentType, parentID, emoji) => {
     const params = new URLSearchParams({ emoji: emoji })
 
     const res = await client.delete(
-        `social/reaction/${parentType}/${parentID}/?${params.toString()}`,
+        `social/reaction/${parentType}/${parentID}/`,
+        { params },
     )
 
     return res.status

--- a/frontend/src/api/tasks.api.js
+++ b/frontend/src/api/tasks.api.js
@@ -1,14 +1,14 @@
 import client from "@api/client"
 
 export const getTasksByDrawer = async (drawerID, ordering, page) => {
-    const res = await client.get(
-        `tasks?drawer=${drawerID}&ordering=${ordering}&page=${page}`,
-    )
+    const res = await client.get(`tasks/`, {
+        params: { drawer: drawerID, ordering, page },
+    })
     return res.data
 }
 
 export const getTask = async (id) => {
-    const res = await client.get(`tasks/${id}`)
+    const res = await client.get(`tasks/${id}/`)
     return res.data
 }
 
@@ -18,12 +18,12 @@ export const postTask = async (task) => {
 }
 
 export const patchTask = async (id, edit) => {
-    const res = await client.patch(`tasks/${id}`, edit)
+    const res = await client.patch(`tasks/${id}/`, edit)
     return res.data
 }
 
 export const deleteTask = async (id) => {
-    const res = await client.delete(`tasks/${id}`)
+    const res = await client.delete(`tasks/${id}/`)
     return res.data
 }
 

--- a/frontend/src/api/today.api.js
+++ b/frontend/src/api/today.api.js
@@ -1,27 +1,27 @@
 import client from "@api/client"
 
 export const getTasksAssignedToday = async (date, page) => {
-    const res = await client.get(`today/assigned`, { params: { date, page } })
+    const res = await client.get(`today/assigned/`, { params: { date, page } })
     return res.data
 }
 
 export const getTasksTodayDue = async (page) => {
-    const res = await client.get(`today/todayDue`, { params: { page } })
+    const res = await client.get(`today/todayDue/`, { params: { page } })
     return res.data
 }
 
 export const getTasksOverDue = async (page) => {
-    const res = await client.get(`today/overDue`, { params: { page } })
+    const res = await client.get(`today/overDue/`, { params: { page } })
     return res.data
 }
 
 export const getTasksPastAssigned = async (page) => {
-    const res = await client.get(`today/pastAssigned`, { params: { page } })
+    const res = await client.get(`today/pastAssigned/`, { params: { page } })
     return res.data
 }
 
 export const getTasksTodayAssignedGrouped = async (tz) => {
-    const res = await client.get(`today/assigned/grouped`, {
+    const res = await client.get(`today/assigned/grouped/`, {
         params: { tz },
     })
     const items = res.data

--- a/frontend/src/api/users.api.js
+++ b/frontend/src/api/users.api.js
@@ -1,7 +1,7 @@
 import client, { getCurrentUsername, setCurrentUsername } from "@api/client"
 
 export const getMe = async () => {
-    const res = await client.get("users/me")
+    const res = await client.get("users/me/")
     setCurrentUsername(res.data.username)
     return res.data
 }


### PR DESCRIPTION
## 문제 상황

- URL 맨 뒤의 `/`가 있는 엔드포인트와 없는 엔드포인트가 혼재
- 프론트엔드에서 `/`를 빼먹고 요청할 시 리다이렉트가 발생하여 하나의 요청으로 처리할 수 있는 것이 두 번의 요청(리다이렉트 → 원래 응답)이 발생하는 문제

## 백엔드

- `backend/*/urls.py`: '모든 URL은 확실해야 한다'는 [장고 철학](https://docs.djangoproject.com/en/4.2/misc/design-philosophies/#definitive-urls)에 맞도록 모든 `urls.py`의 모든 URL 뒤에 슬래시를 추가했습니다.
- `backend/django_peak/settings.py`: [`APPEND_SLASH`](https://docs.djangoproject.com/en/4.2/ref/settings/#append-slash) 값을 거짓으로 설정해서 `/`가 없는 요청이 들어오면 404가 표시되도록 수정했습니다. 
- `backend/Dockerfile`: `health/ok`를 `health/ok/`로 수정했습니다.
- `backend/tasks/views.py`: `ordering`이 `None`인 경우에 대응하는 조건문을 추가했습니다.

## 프론트엔드

- `frontend/src/api/*.api.js`: 모든 URL 뒤에 슬래시를 추가했습니다.