### PR TITLE
FilterButtonGroup 타입화 & 처음에는 transition이 실행되지 않도록 수정

### DIFF
--- a/frontend/src/components/common/FilterButtonGroup.tsx
+++ b/frontend/src/components/common/FilterButtonGroup.tsx
@@ -12,6 +12,12 @@ import MildButton from "@components/common/MildButton"
 
 import { cubicBeizer } from "@assets/keyframes"
 
+interface ButtonPosition {
+    top: number
+    left: number
+    width: number
+}
+
 interface Filter {
     display: string
 }
@@ -27,11 +33,12 @@ const FilterButtonGroup = ({
     setActive,
     filters,
 }: FilterButtonGroupProp) => {
-    const [selectedButtonPosition, setSelectedButtonPosition] = useState({
-        top: 0,
-        left: 0,
-        width: 0,
-    })
+    const [selectedButtonPosition, setSelectedButtonPosition] =
+        useState<ButtonPosition>({
+            top: 0,
+            left: 0,
+            width: 0,
+        })
 
     const onRefChange = useCallback(
         (node: HTMLElement | null) => {
@@ -54,11 +61,7 @@ const FilterButtonGroup = ({
     return (
         <FilterGroupWrapper>
             <FilterGroup>
-                <BackgroundButton
-                    $top={selectedButtonPosition.top}
-                    $left={selectedButtonPosition.left}
-                    $width={selectedButtonPosition.width}
-                />
+                <BackgroundButton $position={selectedButtonPosition} />
                 {filterEntries.map(([name, { display }]) => (
                     <FilterButton
                         ref={active === name ? onRefChange : undefined}
@@ -103,18 +106,12 @@ const FilterButton = styled(MildButton)`
     z-index: 3;
 `
 
-interface BackgroundButtonProp {
-    $top: number
-    $left: number
-    $width: number
-}
-
-const BackgroundButton = styled(MildButton)<BackgroundButtonProp>`
+const BackgroundButton = styled(MildButton)<{ $position: ButtonPosition }>`
     position: absolute;
 
-    top: ${(props) => props.$top - 1}px;
-    left: ${(props) => props.$left}px;
-    width: ${(props) => props.$width}px;
+    top: ${(props) => props.$position.top - 1}px;
+    left: ${(props) => props.$position.left}px;
+    width: ${(props) => props.$position.width}px;
 
     transition:
         top 0.25s ${cubicBeizer},

--- a/frontend/src/components/common/FilterButtonGroup.tsx
+++ b/frontend/src/components/common/FilterButtonGroup.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useState } from "react"
+import {
+    type Dispatch,
+    type SetStateAction,
+    useCallback,
+    useMemo,
+    useState,
+} from "react"
 
 import styled from "styled-components"
 
@@ -6,16 +12,31 @@ import MildButton from "@components/common/MildButton"
 
 import { cubicBeizer } from "@assets/keyframes"
 
-const FilterButtonGroup = ({ active, setActive, filters }) => {
+interface Filter {
+    display: string
+}
+
+interface FilterButtonGroupProp {
+    active: string
+    setActive: Dispatch<SetStateAction<string>>
+    filters: { [name: string]: Filter }
+}
+
+const FilterButtonGroup = ({
+    active,
+    setActive,
+    filters,
+}: FilterButtonGroupProp) => {
     const [selectedButtonPosition, setSelectedButtonPosition] = useState({
-        top: "0.5em",
+        top: 0,
         left: 0,
         width: 0,
     })
 
     const onRefChange = useCallback(
-        (node) => {
+        (node: HTMLElement | null) => {
             if (!node) {
+                // node is null when this component is unmounted
                 return
             }
 
@@ -28,6 +49,8 @@ const FilterButtonGroup = ({ active, setActive, filters }) => {
         [filters],
     )
 
+    const filterEntries = useMemo(() => Object.entries(filters), [filters])
+
     return (
         <FilterGroupWrapper>
             <FilterGroup>
@@ -36,13 +59,12 @@ const FilterButtonGroup = ({ active, setActive, filters }) => {
                     $left={selectedButtonPosition.left}
                     $width={selectedButtonPosition.width}
                 />
-                {Object.entries(filters).map(([name, filter]) => (
+                {filterEntries.map(([name, { display }]) => (
                     <FilterButton
                         ref={active === name ? onRefChange : undefined}
                         key={name}
-                        onClick={() => setActive(name)}
-                        $active={active === name}>
-                        {filter.display}
+                        onClick={() => setActive(name)}>
+                        {display}
                     </FilterButton>
                 ))}
             </FilterGroup>
@@ -81,7 +103,13 @@ const FilterButton = styled(MildButton)`
     z-index: 3;
 `
 
-const BackgroundButton = styled(MildButton)`
+interface BackgroundButtonProp {
+    $top: number
+    $left: number
+    $width: number
+}
+
+const BackgroundButton = styled(MildButton)<BackgroundButtonProp>`
     position: absolute;
 
     top: ${(props) => props.$top - 1}px;

--- a/frontend/src/components/common/FilterButtonGroup.tsx
+++ b/frontend/src/components/common/FilterButtonGroup.tsx
@@ -61,7 +61,9 @@ const FilterButtonGroup = ({
     return (
         <FilterGroupWrapper>
             <FilterGroup>
-                <BackgroundButton $position={selectedButtonPosition} />
+                {selectedButtonPosition.left !== 0 && (
+                    <BackgroundButton $position={selectedButtonPosition} />
+                )}
                 {filterEntries.map(([name, { display }]) => (
                     <FilterButton
                         ref={active === name ? onRefChange : undefined}

--- a/frontend/src/components/intro/DemoTheme.tsx
+++ b/frontend/src/components/intro/DemoTheme.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { type Dispatch, type SetStateAction, useMemo, useState } from "react"
 
 import styled, {
     type LightDark,
@@ -34,7 +34,7 @@ const DemoTheme = () => {
         <SubSection>
             <FilterButtonGroup
                 active={activeTheme}
-                setActive={setActiveTheme}
+                setActive={setActiveTheme as Dispatch<SetStateAction<string>>}
                 filters={filters}
             />
             <Wrapper>


### PR DESCRIPTION
- NotificationsPage와 DemoTheme(IntroPage 속)에서 쓰이는 `FilterButtonGroup`을 타입화했습니다.
- `FilterButtonGroup`의 transition이 처음에는 실행되지 않도록 수정했습니다.

| Before | After |
|---|---|
| https://github.com/user-attachments/assets/bcf46f44-f142-41b6-ba5d-d3451c0a1c23 | https://github.com/user-attachments/assets/5f13df73-eb47-43a0-8fbd-d0eefa2b7cde |



