### PR TITLE
홈의 프로필 사진 로딩 조건을 isLoading으로 변경

### DIFF
--- a/frontend/src/components/home/Header.tsx
+++ b/frontend/src/components/home/Header.tsx
@@ -15,10 +15,9 @@ import FeatherIcon from "feather-icons-react"
 import { useTranslation } from "react-i18next"
 
 const Header = () => {
-    const { data: me, isFetching } = useQuery({
+    const { data: me, isLoading } = useQuery({
         queryKey: ["users", "me"],
         queryFn: () => getMe(),
-        staleTime: 1000 * 60 * 5, // 5 minutes
     })
 
     const { t } = useTranslation("home", { keyPrefix: "page" })
@@ -27,7 +26,7 @@ const Header = () => {
         <Frame>
             <PageTitle>{t("title")}</PageTitle>
             <HeaderIcons>
-                {isFetching ? (
+                {isLoading ? (
                     <HeaderProfileLoading />
                 ) : (
                     <Link to={`/app/users/@${me.username}`}>


### PR DESCRIPTION
- `frontend/src/components/home/Header.tsx`를 타입화했습니다.
- 동 파일의 로딩 조건을 `isFetching`에서 `isLoading`으로 변경해 캐시가 있을 경우 스켈레톤이 표시되지 않도록 수정했습니다.