### PR TITLE
Sidebar 일부 타입화 & SidebarLink 일부 prop 제거

### DIFF
--- a/frontend/src/components/sidebar/Footer.tsx
+++ b/frontend/src/components/sidebar/Footer.tsx
@@ -3,7 +3,10 @@ import { useEffect } from "react"
 import { useQuery } from "@tanstack/react-query"
 import styled, { css } from "styled-components"
 
-import { useSidebarContext } from "@components/sidebar/SidebarContext"
+import {
+    StyledCollapsedProp,
+    useSidebarContext,
+} from "@components/sidebar/SidebarContext"
 import SidebarLink from "@components/sidebar/SidebarLink"
 
 import { getMe } from "@api/users.api"
@@ -17,14 +20,14 @@ import { toast } from "react-toastify"
 const Footer = () => {
     const {
         data: user,
-        isPending,
+        isLoading,
         isError,
     } = useQuery({
         queryKey: ["users", "me"],
         queryFn: () => getMe(),
     })
 
-    const { t } = useTranslation(null, { keyPrefix: "sidebar" })
+    const { t } = useTranslation("translation", { keyPrefix: "sidebar" })
 
     useEffect(() => {
         if (isError) {
@@ -38,7 +41,7 @@ const Footer = () => {
 
     return (
         <FooterBox $collapsed={isCollapsed}>
-            {isPending && (
+            {isLoading && (
                 <MeProfile>
                     <MeProfileImgSkeleton />
                     {!isCollapsed && <UsernameSkeleton />}
@@ -61,7 +64,6 @@ const Footer = () => {
                     <SidebarLink
                         to="/app/settings/profile"
                         activePath="/app/settings"
-                        end={false}
                         key="settings">
                         <SmallIcon>
                             <FeatherIcon icon="settings" />
@@ -73,7 +75,7 @@ const Footer = () => {
     )
 }
 
-const FooterBox = styled.footer`
+const FooterBox = styled.footer<StyledCollapsedProp>`
     display: flex;
     flex-direction: ${(props) => (props.$collapsed ? "column" : "row")};
     justify-content: space-between;

--- a/frontend/src/components/sidebar/Header.tsx
+++ b/frontend/src/components/sidebar/Header.tsx
@@ -68,19 +68,22 @@ const Header = () => {
     )
 }
 
-const ButtonContainer = styled.div`
+interface CollapsedProp {
+    $collapsed?: boolean
+}
+
+const ButtonContainer = styled.div<CollapsedProp>`
     display: flex;
     justify-content: flex-end;
     font-size: 1em;
     padding: 0.75em 0.5em 0.75em 0.5em;
     margin: 0 0.75em;
 
-    ${({ $collapsed }) =>
-        $collapsed
-            ? css`
-                  justify-content: center;
-              `
-            : null}
+    ${(prop) =>
+        prop.$collapsed &&
+        css`
+            justify-content: center;
+        `}
 `
 const rotateToLeft = keyframes`
     0% {
@@ -102,7 +105,7 @@ const rotateToRight = keyframes`
     }
 `
 
-const CollapseButton = styled(MildButton)`
+const CollapseButton = styled(MildButton)<CollapsedProp>`
     padding: 0.75em;
 
     & svg {

--- a/frontend/src/components/sidebar/Header.tsx
+++ b/frontend/src/components/sidebar/Header.tsx
@@ -3,7 +3,10 @@ import { useEffect, useRef } from "react"
 import styled, { css, keyframes } from "styled-components"
 
 import MildButton from "@components/common/MildButton"
-import { useSidebarContext } from "@components/sidebar/SidebarContext"
+import {
+    type StyledCollapsedProp,
+    useSidebarContext,
+} from "@components/sidebar/SidebarContext"
 
 import useScreenSize from "@utils/useScreenSize"
 import { WIDTH_TABLET } from "@utils/useScreenType"
@@ -68,11 +71,7 @@ const Header = () => {
     )
 }
 
-interface CollapsedProp {
-    $collapsed?: boolean
-}
-
-const ButtonContainer = styled.div<CollapsedProp>`
+const ButtonContainer = styled.div<StyledCollapsedProp>`
     display: flex;
     justify-content: flex-end;
     font-size: 1em;
@@ -105,7 +104,7 @@ const rotateToRight = keyframes`
     }
 `
 
-const CollapseButton = styled(MildButton)<CollapsedProp>`
+const CollapseButton = styled(MildButton)<StyledCollapsedProp>`
     padding: 0.75em;
 
     & svg {

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -3,7 +3,10 @@ import styled, { css } from "styled-components"
 import Footer from "@components/sidebar/Footer"
 import Header from "@components/sidebar/Header"
 import Middle from "@components/sidebar/Middle"
-import { useSidebarContext } from "@components/sidebar/SidebarContext"
+import {
+    type StyledCollapsedProp,
+    useSidebarContext,
+} from "@components/sidebar/SidebarContext"
 
 import { ifMobile } from "@utils/useScreenType"
 
@@ -19,7 +22,7 @@ const Sidebar = () => {
     )
 }
 
-export const SidebarBox = styled.nav`
+export const SidebarBox = styled.nav<StyledCollapsedProp>`
     z-index: 99;
 
     padding-bottom: calc(env(safe-area-inset-bottom) - 1em);

--- a/frontend/src/components/sidebar/SidebarContext.tsx
+++ b/frontend/src/components/sidebar/SidebarContext.tsx
@@ -12,6 +12,10 @@ import { WIDTH_TABLET } from "@utils/useScreenType"
 
 const startUpWidth = window.innerWidth
 
+export interface StyledCollapsedProp {
+    $collapsed?: boolean
+}
+
 interface SidebarCollapsed {
     isCollapsed: boolean
     setCollapsed: Dispatch<SetStateAction<boolean>>

--- a/frontend/src/components/sidebar/SidebarContext.tsx
+++ b/frontend/src/components/sidebar/SidebarContext.tsx
@@ -1,13 +1,32 @@
-import { createContext, useContext, useState } from "react"
+import {
+    type Dispatch,
+    type ReactNode,
+    type SetStateAction,
+    createContext,
+    useContext,
+    useState,
+} from "react"
 
 import { useClientSetting } from "@utils/clientSettings"
 import { WIDTH_TABLET } from "@utils/useScreenType"
 
 const startUpWidth = window.innerWidth
 
-const SidebarContext = createContext()
+interface SidebarCollapsed {
+    isCollapsed: boolean
+    setCollapsed: Dispatch<SetStateAction<boolean>>
+}
 
-export const SidebarContextProvider = ({ children }) => {
+const SidebarContext = createContext<SidebarCollapsed>({
+    isCollapsed: false,
+    setCollapsed: () => {},
+})
+
+export const SidebarContextProvider = ({
+    children,
+}: {
+    children?: ReactNode
+}) => {
     const [clientSetting] = useClientSetting()
 
     const [isCollapsed, setCollapsed] = useState(

--- a/frontend/src/components/sidebar/SidebarLink.tsx
+++ b/frontend/src/components/sidebar/SidebarLink.tsx
@@ -1,10 +1,10 @@
+import { type MouseEvent } from "react"
 import {
-    type MouseEvent,
-    type MouseEventHandler,
-    type ReactNode,
-    startTransition,
-} from "react"
-import { NavLink, type To, useNavigate } from "react-router-dom"
+    NavLink,
+    type NavLinkProps,
+    type To,
+    useNavigate,
+} from "react-router-dom"
 
 import styled from "styled-components"
 
@@ -29,53 +29,30 @@ const StyledNavLink = styled(NavLink)`
     }
 `
 
-interface SidebarLinkProp {
-    onClick?: MouseEventHandler
-    to: To
+interface SidebarLinkProp extends NavLinkProps {
+    // use if navigated path and active path are different. If empty, then 'to' is used.
     activePath: To
-    end?: boolean
-    children?: ReactNode
-    lazy?: boolean
-    noNavigate?: boolean
 }
 
 const SidebarLink = ({
-    onClick, // onClick is called before navigate().
     to,
-    activePath, // use if navigated path and active path are different. If empty, then 'to' is used.
-    end = false,
+    activePath,
     children,
-    lazy = false, // if true, then navigate() is called inside startTransition().
-    noNavigate = false, // if true, then navigate() isn't called.
+    ...others
 }: SidebarLinkProp) => {
     const navigate = useNavigate()
 
-    const onClickThis = (e: MouseEvent) => {
+    const onClick = (e: MouseEvent) => {
         e.preventDefault()
-
-        if (onClick) {
-            onClick(e)
-        }
-
-        if (noNavigate) {
-            return
-        }
-
-        if (lazy) {
-            startTransition(() => {
-                navigate(to)
-            })
-        } else {
-            navigate(to)
-        }
+        navigate(to)
     }
 
     return (
         <StyledNavLink
-            onClick={onClickThis}
+            onClick={onClick}
             to={activePath || to}
             draggable="false"
-            end={end}>
+            {...others}>
             {children}
         </StyledNavLink>
     )

--- a/frontend/src/components/sidebar/SidebarLink.tsx
+++ b/frontend/src/components/sidebar/SidebarLink.tsx
@@ -1,5 +1,10 @@
-import { startTransition } from "react"
-import { NavLink, useNavigate } from "react-router-dom"
+import {
+    type MouseEvent,
+    type MouseEventHandler,
+    type ReactNode,
+    startTransition,
+} from "react"
+import { NavLink, type To, useNavigate } from "react-router-dom"
 
 import styled from "styled-components"
 
@@ -24,18 +29,28 @@ const StyledNavLink = styled(NavLink)`
     }
 `
 
+interface SidebarLinkProp {
+    onClick?: MouseEventHandler
+    to: To
+    activePath: To
+    end?: boolean
+    children?: ReactNode
+    lazy?: boolean
+    noNavigate?: boolean
+}
+
 const SidebarLink = ({
     onClick, // onClick is called before navigate().
     to,
     activePath, // use if navigated path and active path are different. If empty, then 'to' is used.
-    end,
+    end = false,
     children,
     lazy = false, // if true, then navigate() is called inside startTransition().
     noNavigate = false, // if true, then navigate() isn't called.
-}) => {
+}: SidebarLinkProp) => {
     const navigate = useNavigate()
 
-    const onClickThis = (e) => {
+    const onClickThis = (e: MouseEvent) => {
         e.preventDefault()
 
         if (onClick) {

--- a/frontend/src/components/sidebar/SidebarLink.tsx
+++ b/frontend/src/components/sidebar/SidebarLink.tsx
@@ -31,7 +31,7 @@ const StyledNavLink = styled(NavLink)`
 
 interface SidebarLinkProp extends NavLinkProps {
     // use if navigated path and active path are different. If empty, then 'to' is used.
-    activePath: To
+    activePath?: To
 }
 
 const SidebarLink = ({


### PR DESCRIPTION
이하의 파일을 타입화했습니다.

- `frontend/src/components/sidebar/Footer.tsx`
- `frontend/src/components/sidebar/Header.tsx`
- `frontend/src/components/sidebar/SidebarLink.tsx`
- `frontend/src/components/sidebar/Sidebar.tsx`
- `frontend/src/components/sidebar/SidebarContext.tsx`

`frontend/src/components/sidebar/Middle.jsx`은 `project`가 타입화가 된 후에 수정하도록 하겠습니다.

- `frontend/src/components/sidebar/SidebarLink.tsx`: `onClick`, `lazy`, `noNavigate`가 더 이상 쓰이지 않아서 제거했습니다.