### PR TITLE
설정>프로필에서 유저네임 아래가 짤리는 문제 해결

### DIFF
--- a/frontend/src/pages/settings/Profile.jsx
+++ b/frontend/src/pages/settings/Profile.jsx
@@ -155,7 +155,6 @@ const Profile = () => {
                         <Button
                             disabled={mutation.isPending}
                             loading={mutation.isPending}
-                            form="filled"
                             type="submit">
                             {t("button_submit")}
                         </Button>
@@ -192,7 +191,7 @@ const Username = styled.div`
 
     min-width: 0;
     white-space: nowrap;
-    overflow: hidden;
+    overflow-x: clip;
     text-overflow: ellipsis;
 `
 


### PR DESCRIPTION
**설정>프로필**에서 유저네임에 g, q, p 같은 글자가 포함될 시 아래가 잘려보이던 문제를 해결했습니다.

| Before | After |
|---|---|
| <img width="349" alt="Screenshot 2025-03-27 at 15 07 07" src="https://github.com/user-attachments/assets/5b8fab20-e14e-4594-891b-522482a78703" /> | <img width="349" alt="Screenshot 2025-03-27 at 15 07 00" src="https://github.com/user-attachments/assets/66a9f0b4-bff9-4093-86c3-83dd2cf7c6d7" /> |

