### PR TITLE
작업 생성 시 뜨던 405 에러 수정

### DIFF
--- a/backend/notifications/urls.py
+++ b/backend/notifications/urls.py
@@ -8,9 +8,9 @@ urlpatterns = [
     path("", views.NotificationList.as_view()),
     path("subscribe/", views.WebPushSubscriptionCreate.as_view()),
     path("subscribe/<str:id>/", views.WebPushSubscriptionDetail.as_view()),
-    path("<str:id>/", views.NotificationDetail.as_view()),
     path("reminders/", views.ReminderList.as_view()),
     path("reminders/<str:id>/", views.ReminderDetail.as_view()),
+    path("<str:id>/", views.NotificationDetail.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)


### PR DESCRIPTION
`notifications.urls.py`에서 `path("<str:id>/", ...)`이 `path("reminders/", ...)`보다 위에 있어 405에러가 뜨던 오류를 수정하였습니다.