### PR TITLE
TodayPage에 TaskCreateSimple 추가

### DIFF
--- a/backend/today/views.py
+++ b/backend/today/views.py
@@ -21,7 +21,7 @@ class TaskTodayAssignedList(mixins.ListModelMixin, generics.GenericAPIView):
             Task.objects.filter(
                 user=self.request.user, assigned_at=date, completed_at__isnull=True
             )
-            .order_by("-priority", "due_date")
+            .order_by("-priority", "due_date", "created_at")
             .all()
         )
 

--- a/frontend/src/components/drawers/TaskCreateButton.jsx
+++ b/frontend/src/components/drawers/TaskCreateButton.jsx
@@ -1,0 +1,48 @@
+import styled from "styled-components"
+
+import FeatherIcon from "feather-icons-react"
+import { useTranslation } from "react-i18next"
+
+const TaskCreateButton = ({ isOpen, onClick }) => {
+    const { t } = useTranslation("translation", { keyPrefix: "project" })
+
+    return (
+        <TaskCreateButtonBox onClick={onClick}>
+            {isOpen ? (
+                <>
+                    <FeatherIcon icon="x-circle" />
+                    <TaskCreateText>
+                        {t("button_close_add_task")}
+                    </TaskCreateText>
+                </>
+            ) : (
+                <>
+                    <FeatherIcon icon="plus-circle" />
+                    <TaskCreateText>{t("button_add_task")}</TaskCreateText>
+                </>
+            )}
+        </TaskCreateButtonBox>
+    )
+}
+
+const TaskCreateButtonBox = styled.div`
+    display: flex;
+    align-items: center;
+    margin-top: 1em;
+    margin-left: 1.9em;
+    cursor: pointer;
+    & svg {
+        width: 1.1em;
+        height: 1.1em;
+        top: 0;
+    }
+`
+
+const TaskCreateText = styled.div`
+    font-size: 1.1em;
+    font-weight: medium;
+    color: ${(p) => p.theme.textColor};
+    margin-top: 0em;
+`
+
+export default TaskCreateButton

--- a/frontend/src/components/project/TaskCreateSimple/index.jsx
+++ b/frontend/src/components/project/TaskCreateSimple/index.jsx
@@ -27,12 +27,15 @@ const TaskCreateSimple = ({
     drawerName,
     color,
     onClose,
+    init_assigned_at = null,
 }) => {
     const { t } = useTranslation(null, { keyPrefix: "task.edit" })
     const inputRef = useRef(null)
 
     const [content, setContent] = useState("name")
-    const [assignedIndex, setAssignedIndex] = useState(0)
+    const [assignedIndex, setAssignedIndex] = useState(
+        init_assigned_at !== null ? 1 : 0,
+    )
     const [dueIndex, setDueIndex] = useState(0)
     const [priorityIndex, setPriorityIndex] = useState(0)
 
@@ -63,7 +66,7 @@ const TaskCreateSimple = ({
 
     const [newTask, setNewTask] = useState({
         name: "",
-        assigned_at: null,
+        assigned_at: init_assigned_at,
         due_type: null,
         due_date: null,
         due_datetime: null,
@@ -94,6 +97,9 @@ const TaskCreateSimple = ({
             })
             queryClient.invalidateQueries({
                 queryKey: ["project", newTask.project_id],
+            })
+            queryClient.invalidateQueries({
+                queryKey: ["today", "assigned"],
             })
             toast.success(t("create_success"))
             onClose()


### PR DESCRIPTION
<img width="1008" alt="스크린샷 2025-04-08 오후 6 27 50" src="https://github.com/user-attachments/assets/cf31ece3-4d71-40ca-8119-e4db98bac859" />

- `TodayPage`에 `TaskCreateSimple`를 추가하였습니다.
- `assigned_at`이 오늘로 자동설정되며, 프로젝트는 인박스로 생성됩니다.
- 생성 시 `task`의 정렬을 자연스럽게 하기 위해 `created_at`을 `order_by`에 추가하였습니다.