### PR TITLE
NotificationsPage에서 로딩이 되지 않던 문제 해결

### DIFF
--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -185,6 +185,7 @@ const RefetchIcon = styled.div`
     align-items: center;
     height: 1.75em;
     padding: 0 0.5em;
+    cursor: pointer;
 
     & svg {
         stroke-width: 3px;

--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -57,9 +57,9 @@ const NotificationsPage = () => {
         isFetching,
         isFetchingNextPage,
     } = useInfiniteQuery({
-        queryKey: ["notifications", { types: filters[activeFilter] }],
+        queryKey: ["notifications", filters[activeFilter]],
         queryFn: (context) =>
-            getNotifications(context.pageParam, context.queryKey[1]),
+            getNotifications(context.pageParam, context.queryKey[1].types),
         initialPageParam: "",
         getNextPageParam: (lastPage) => getCursorFromURL(lastPage.next),
         gcTime: 30 * 1000,


### PR DESCRIPTION
#435 PR 이후 NotificationsPage에서 로딩이 되지 않던 문제를 해결했습니다.

- 원인: 올바르지 않은 `queryKey` 지정으로 인해 호출 함수로 데이터가 넘어가지 않음
- 해결: `queryKey` 수정