### PR TITLE
Bump random-reviewer-discord from 0.2.1 to 0.2.2

### DIFF
--- a/.github/workflows/reviewer.yaml
+++ b/.github/workflows/reviewer.yaml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Run random-reviewer-discord
-        uses: JedBeom/random-reviewer-discord@v0.2.1
+        uses: JedBeom/random-reviewer-discord@v0.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
random-reviewer-discord 액션을 0.2.2로 업데이트합니다.
변경사항은 다음과 같습니다:
- 풀 리퀘스트 저자가 스스로 리뷰 코멘트를 작성했을 때(코멘트 답장도 포함) 디스코드 알림이 발생하던 문제 해결