### PR TITLE
Bump pnpm to v10

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -57,7 +57,7 @@ cp .env.example .env
 다른 터미널(또는 VSCode +버튼 눌러서 터미널 탭 추가)에서 `./frontend`에서
 
 ```bash
-npm install -g pnpm@9 # install pnpm v9
+npm install -g pnpm # install pnpm 
 pnpm i # install dependencies
 pnpm dev # start dev server
 ```

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:lts-alpine
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN npm install -g corepack@latest
-RUN corepack use pnpm@9.x
+RUN corepack use pnpm@10.x
 RUN corepack enable
 
 WORKDIR /frontend

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,9 +2,7 @@
 
 ## Start
 
-If you don't have pnpm, then check out [pnpm installation guide](https://pnpm.io/installation).
-
-> Note that Peak uses `pnpm@9`. (not the latest v10!)
+If you don't have pnpm, then check out the [pnpm installation guide](https://pnpm.io/installation).
 
 ```bash
 pnpm i

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "version": "0.0.0",
     "type": "module",
-    "packageManager": "pnpm@9.15.5",
+    "packageManager": "pnpm@10.13.1",
     "scripts": {
         "preinstall": "npx only-allow pnpm",
         "dev": "vite",
@@ -66,13 +66,5 @@
         "vite": "^7.0.3",
         "vite-plugin-pwa": "^1.0.1",
         "workbox-precaching": "^7.3.0"
-    },
-    "pnpm": {
-        "overrides": {
-            "puppeteer": "0.0.0"
-        },
-        "allowedDeprecatedVersions": {
-            "puppeteer": "0.0.0"
-        }
     }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  puppeteer: 0.0.0
-
 importers:
 
   .:


### PR DESCRIPTION
dependabot이 [pnpm v10을 지원](https://github.com/dependabot/dependabot-core/issues/11246#issuecomment-2935428790)하기 시작했습니다. 우리 프로젝트의 pnpm도 v9에서 v10으로 판올림합니다.