### PR TITLE
홈의 PWA 유도 모듈의 출현 조건 지정

### DIFF
--- a/frontend/src/components/home/InstallPeak.tsx
+++ b/frontend/src/components/home/InstallPeak.tsx
@@ -4,8 +4,14 @@ import Module, { Center, CenteredText, Title } from "@components/home/Module"
 
 import { useTranslation } from "react-i18next"
 
+const isStandalone = window.matchMedia("(display-mode: standalone)").matches
+
 const InstallPeak = () => {
     const { t } = useTranslation("home", { keyPrefix: "install_peak" })
+
+    if (!("standalone" in window.navigator) || isStandalone) {
+        return null
+    }
 
     return (
         <Module to="/docs/install-instruction">


### PR DESCRIPTION
'Peak을 앱처럼 사용하기' 모듈이 전부 노출에서 'PWA를 설치할 수 있는 Safari 환경이고 PWA가 아닐 때'로 변경했습니다.

| Firefox | iOS (미설치) | iOS (PWA 속) |
|--|--|--|
| <img width="782" height="660" alt="Screenshot 2025-08-24 at 17 42 22" src="https://github.com/user-attachments/assets/ade29dd6-28b6-44ae-8dcf-007c50e82115" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-24 at 17 42 28" src="https://github.com/user-attachments/assets/7bc4ebd2-26e0-4322-935b-0725da31e8e7" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-24 at 17 42 43" src="https://github.com/user-attachments/assets/be4d48e7-b4e4-4c2b-b6c1-8a586b0cf76e" /> |

안드로이드 환경은 당장 테스트할 기기가 없고 안드로이드용 설치 가이드도 제작이 되지 않은 관계로 추후 지원할 계획입니다.


