### PR TITLE
내 팔로잉이 없을 때 소셜 팔로잉 페이지에서 400 오류 해결

### DIFF
--- a/backend/social/views.py
+++ b/backend/social/views.py
@@ -452,7 +452,9 @@ class StatList(TimezoneMixin, generics.GenericAPIView):
             user_ids  # pyright: ignore [reportArgumentType] -- ValuesQuerySet is compatible with QuerySet
         )
         if not paginated_user_ids:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                self.paginator.get_paginated_data(paginated_user_ids)  # pyright: ignore[reportAttributeAccessIssue] -- StatListPagination has get_paginated_data method
+            )
 
         date = datetime.date.fromisoformat(date_iso)
         datetime_range = self.get_datetime_range(date)


### PR DESCRIPTION
내가 팔로잉하는 사용자가 없을 때 소셜 팔로잉 페이지에서 400이 발생하던 문제를 해결했습니다.