### PR TITLE
html의 width를 100%로 수정

### DIFF
--- a/frontend/public/global.css
+++ b/frontend/public/global.css
@@ -68,8 +68,8 @@ table {
 }
 
 html {
-    height: 100dvh;
-    width: 100vw;
+    min-height: 100dvh;
+    width: 100%;
     scrollbar-width: thin;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
- `html`의 `width`가 `100vw`로 설정되어 있어 가로 스크롤이 생기는 문제가 있어 `100%`로 변경하고 `height`도 `min-height`로 설정해 불필요한 스크롤바가 생길 상황을 최소화했습니다.
- 원래 `overflow-x: hidden`으로 설정되어 있어 문제 파악을 못했는데, `useStopScroll` 오류로 발견했습니다.

## 테스트 플랜

- `100vw`인 상태에서 `body`에 `overflow: auto`를 추가하고, 가로 스크롤바가 생기는 것을 확인한다.
- `100%`로 속성을 변경하고 브라우저 새로고침 후 `overflow` 속성을 추가해도 가로 스크롤바가 생기지 않는 것을 확인한다.
