### PR TITLE
days_left 영문 번역에서 띄어쓰기가 되지 않던 문제 해결

### DIFF
--- a/frontend/src/assets/locales/en/translation.json
+++ b/frontend/src/assets/locales/en/translation.json
@@ -157,7 +157,7 @@
         "overdue": "Overdue",
         "due_today": "Today",
         "due_tomorrow": "Tomorrow",
-        "days_left": "days left",
+        "days_left": "{{diff}} days left",
         "name_placeholder": "Enter a name for the task.",
         "name_change_success": "The name has changed.",
         "none": "none",

--- a/frontend/src/assets/locales/ko/translation.json
+++ b/frontend/src/assets/locales/ko/translation.json
@@ -157,7 +157,7 @@
         "overdue": "기한 지남",
         "due_today": "오늘",
         "due_tomorrow": "내일",
-        "days_left": "일 남음",
+        "days_left": "{{diff}}일 남음",
         "name_placeholder": "작업의 이름을 입력하세요.",
         "name_change_success": "이름을 변경했습니다.",
         "none": "없음",

--- a/frontend/src/components/tasks/utils/useTaskDateStatus.tsx
+++ b/frontend/src/components/tasks/utils/useTaskDateStatus.tsx
@@ -43,7 +43,7 @@ const useCalculateDate = (
         } else if (diff_total_days === 1) {
             calculatedDue = t("due_tomorrow")
         } else if (2 <= diff_total_days && diff_total_days <= 30) {
-            calculatedDue = `${diff_total_days}` + t("days_left")
+            calculatedDue = t("days_left", { diff: diff_total_days })
         } else {
             calculatedDue = newDate
         }


### PR DESCRIPTION
- `translation.json`의 `task.days_left` 영문 번역에서 숫자와 단어가 띄어쓰기가 되지 않던 문제가 있었습니다.

```
3days left
```

- 문자열 concat 대신에 번역 내부 변수를 사용하게 하여 언어별로 다르게 처리할 수 있게 수정했습니다.
- `days_left` 번역은 `diff=1`일 때는 쓰이지 않기 때문에 별도의 수사 처리는 하지 않았습니다.