### PR TITLE
PATCH 메소드에 user 객체를 넘겨 작동하지 않던 문제 수정

### DIFF
--- a/frontend/src/api/tasks.api.ts
+++ b/frontend/src/api/tasks.api.ts
@@ -101,18 +101,3 @@ export const deleteTask = async (id: string) => {
     const res = await client.delete(`tasks/${id}/`)
     return res.status
 }
-
-export const completeTask = async (id: string) => {
-    const date = new Date()
-    const edit = {
-        completed_at: date.toISOString(),
-    }
-    return await patchTask(id, edit)
-}
-
-export const uncompleteTask = async (id: string) => {
-    const edit = {
-        completed_at: null,
-    }
-    return await patchTask(id, edit)
-}

--- a/frontend/src/components/project/edit/DrawerEdit.tsx
+++ b/frontend/src/components/project/edit/DrawerEdit.tsx
@@ -80,7 +80,13 @@ const DrawerEdit = ({ drawer }: { drawer?: Drawer }) => {
 
     const patchMutation = useMutation({
         mutationFn: (data: Drawer) => {
-            const drawerData = { ...data, project: data.project.id }
+            const { id, user, created_at, updated_at, deleted_at, ...rest } =
+                data
+
+            const drawerData = {
+                ...rest,
+                project: data.project.id,
+            }
             return patchDrawer(data.id!, drawerData)
         },
         onSuccess: () => {

--- a/frontend/src/components/project/edit/ProjectEdit.tsx
+++ b/frontend/src/components/project/edit/ProjectEdit.tsx
@@ -51,7 +51,16 @@ const ProjectEdit = ({ project }: { project?: Project }) => {
     const mutation = useMutation({
         mutationFn: (data: Partial<Project>) => {
             if (project) {
-                return patchProject(project.id, data)
+                const {
+                    id,
+                    user,
+                    created_at,
+                    updated_at,
+                    deleted_at,
+                    ...rest
+                } = data
+
+                return patchProject(project.id, rest)
             }
             return postProject(data)
         },

--- a/frontend/src/components/project/taskDetails/TaskDetail.tsx
+++ b/frontend/src/components/project/taskDetails/TaskDetail.tsx
@@ -38,8 +38,11 @@ const TaskDetail = ({ task }: { task: MinimalTaskWithID }) => {
 
     const patchMutation = useMutation({
         mutationFn: (data: MinimalTaskWithID) => {
+            const { id, user, created_at, updated_at, deleted_at, ...rest } =
+                data
+
             const taskData = {
-                ...data,
+                ...rest,
                 drawer: data.drawer.id,
             }
             return patchTask(data.id, taskData)

--- a/frontend/src/components/project/taskDetails/mobile/TaskDetailMobile.tsx
+++ b/frontend/src/components/project/taskDetails/mobile/TaskDetailMobile.tsx
@@ -37,8 +37,11 @@ const TaskDetailMobile = ({
 
     const patchMutation = useMutation({
         mutationFn: (data: MinimalTaskWithID) => {
+            const { id, user, created_at, updated_at, deleted_at, ...rest } =
+                data
+
             const taskData = {
-                ...data,
+                ...rest,
                 drawer: data.drawer.id,
             }
             return patchTask(data.id, taskData)


### PR DESCRIPTION
- `DrawerEdit.tsx`에서 PATCH 시에 id, user, 타임스탬프 필드를 제외한 뒤 백엔드로 전송하도록 수정하였습니다.
- `ProjectEdit.tsx`에서 프로젝트를 수정할 때도 동일하게 id, user, 타임스탬프 필드를 제외하도록 수정하였습니다.
- `TaskDetail.tsx`와 `TaskDetailMobile.tsx`에서 작업을 수정할 때 역시 id, user, 타임스탬프 필드를 제외하도록 수정하였습니다.
- `tasks.api.ts`에서 사용되지 않는 API 함수 completeTask, uncompleteTask를 제거하였습니다.