### PR TITLE
사이드바가 접혔을 때 프로젝트 더 불러오기 버튼이 접히지 않던 문제 해결

### DIFF
--- a/frontend/src/components/sidebar/Middle.tsx
+++ b/frontend/src/components/sidebar/Middle.tsx
@@ -126,6 +126,11 @@ const Middle = () => {
                     <ButtonGroup $justifyContent="center" $margin="1em">
                         <MoreButton
                             $collapsed={isCollapsed}
+                            type="button"
+                            aria-label={
+                                isCollapsed ? t("common.load_more") : undefined
+                            }
+                            aria-busy={isFetchingNextPage}
                             disabled={isFetchingNextPage}
                             loading={isFetchingNextPage}
                             onClick={() => fetchNextPage()}>
@@ -136,7 +141,10 @@ const Middle = () => {
                                     t("common.load_more")
                                 )
                             ) : (
-                                <FeatherIcon icon="chevrons-down" />
+                                <FeatherIcon
+                                    icon="chevrons-down"
+                                    aria-hidden="true"
+                                />
                             )}
                         </MoreButton>
                     </ButtonGroup>

--- a/frontend/src/components/sidebar/Middle.tsx
+++ b/frontend/src/components/sidebar/Middle.tsx
@@ -125,12 +125,19 @@ const Middle = () => {
                 {hasNextPage ? (
                     <ButtonGroup $justifyContent="center" $margin="1em">
                         <MoreButton
+                            $collapsed={isCollapsed}
                             disabled={isFetchingNextPage}
                             loading={isFetchingNextPage}
                             onClick={() => fetchNextPage()}>
-                            {isPending
-                                ? t("common.loading")
-                                : t("common.load_more")}
+                            {!isCollapsed ? (
+                                isPending ? (
+                                    t("common.loading")
+                                ) : (
+                                    t("common.load_more")
+                                )
+                            ) : (
+                                <FeatherIcon icon="chevrons-down" />
+                            )}
                         </MoreButton>
                     </ButtonGroup>
                 ) : null}
@@ -272,8 +279,15 @@ const ProjectLoadErrorBox = styled(ProjectItemBox)<StyledCollapsedProp>`
     }
 `
 
-const MoreButton = styled(Button)`
-    width: 80%;
+const MoreButton = styled(Button)<StyledCollapsedProp>`
+    width: ${(p) => (p.$collapsed ? "100%" : "80%")};
+    padding: ${(p) => (p.$collapsed ? "0.25em" : "0.5em 1em")};
+
+    & svg {
+        top: 0;
+        margin-right: 0;
+        font-size: 1.5em;
+    }
 `
 
 export default Middle

--- a/frontend/src/components/sidebar/Middle.tsx
+++ b/frontend/src/components/sidebar/Middle.tsx
@@ -135,11 +135,7 @@ const Middle = () => {
                             loading={isFetchingNextPage}
                             onClick={() => fetchNextPage()}>
                             {!isCollapsed ? (
-                                isPending ? (
-                                    t("common.loading")
-                                ) : (
-                                    t("common.load_more")
-                                )
+                                t("common.load_more")
                             ) : (
                                 <FeatherIcon
                                     icon="chevrons-down"


### PR DESCRIPTION
Before:
<img width="372" height="269" alt="Screenshot 2025-09-27 at 00 27 40" src="https://github.com/user-attachments/assets/40c1a563-1007-453b-bc17-4d47c0a94e25" />

After:
<img width="372" height="269" alt="Screenshot 2025-09-27 at 00 27 35" src="https://github.com/user-attachments/assets/e05622e2-2273-4232-9303-963e330faab6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사이드바 접힘 상태에 따라 More 버튼이 아이콘(chevrons-down) 또는 텍스트("더 불러오기")로 전환됩니다.
  * 접힘 상태가 버튼에 전달되어 클릭 시 다음 페이지 로드 동작이 유지됩니다.
  * 접근성 속성(aria-label, aria-busy)이 상태에 따라 적절히 설정됩니다.

* **스타일**
  * 접힘 여부에 따라 버튼 너비(100%/80%)와 패딩이 조정됩니다.
  * 아이콘 정렬과 크기 및 마진이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->