### PR TITLE
더 이상 PR이 열렸을 시 리뷰어가 배정되지 않음

### DIFF
--- a/.github/workflows/reviewer.yaml
+++ b/.github/workflows/reviewer.yaml
@@ -3,7 +3,6 @@ name: Random Reviewer Discord
 on:
   pull_request:
     types:
-      - opened
       - review_requested
       - ready_for_review
   pull_request_review:


### PR DESCRIPTION
- 이제 PR을 올려도 무작위 리뷰어 배정이 되지 않습니다.
- 프로젝트 참여 인원이 2명으로 줄어 무작위 배정의 이유가 없습니다.
- CodeRabbit의 리뷰를 해결하고서 사람 리뷰어에게 리뷰 받을 준비가 되었을 때 직접 리뷰 요청하는 것으로 방식을 변경하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - PR 리뷰 관련 워크플로우 트리거를 조정하여, PR 생성 시점이 아닌 리뷰 요청 또는 리뷰 준비 상태에서 실행되도록 변경했습니다.
  - 리뷰 이벤트 처리 방식에는 변경이 없습니다.
  - 애플리케이션 기능이나 사용자 경험에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->