### PR TITLE
리마인더 알림의 제목을 누르면 TaskDetail이 나타나도록 수정

### DIFF
--- a/frontend/src/components/notifications/ContentTitle.tsx
+++ b/frontend/src/components/notifications/ContentTitle.tsx
@@ -25,7 +25,11 @@ const ContentTitle = ({ notification, relatedUser }: ContentTitleProps) => {
             </TitleBox>
         )
     } else if (notification.type === "task_reminder") {
-        const taskURL = "/app/projects/" + notification.task_reminder.project_id
+        const taskURL =
+            "/app/projects/" +
+            notification.task_reminder.project_id +
+            "?taskId=" +
+            notification.task_reminder.task
         return (
             <TitleBox>
                 <ContentTitleLink to={taskURL}>


### PR DESCRIPTION
리마인더 알림의 제목을 누르면 프로젝트 페이지로만 이동했던 것을 TaskDetail까지 나타나도록 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 알림의 작업 리마인더 링크가 프로젝트 페이지로만 이동하던 방식에서, 해당 작업을 직접 가리키도록 개선되었습니다.
  - 링크에 작업 식별자가 포함되어 클릭 시 해당 작업으로 즉시 이동/포커스되어 탐색 시간이 단축됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->