### PR TITLE
StatBoxSkeleton 색상 수정

### DIFF
--- a/frontend/src/components/social/StatContainer.tsx
+++ b/frontend/src/components/social/StatContainer.tsx
@@ -255,13 +255,6 @@ const Box = styled(Link)<{
             border-color: ${p.$borderColor};
             background-color: ${p.theme.backgroundColor};
         `}
-
-    ${(p) =>
-        p.$skeleton &&
-        css`
-            background-color: ${p.theme.skeleton.defaultColor};
-            ${skeletonBreathingCSS}
-        `}
 `
 
 const ProfileImgWrapper = styled.div`
@@ -284,8 +277,9 @@ const ProfileImg = styled.img`
 const ProfileImgSkeleton = styled.div`
     aspect-ratio: 1;
     width: 100%;
-    background-color: ${(p) => p.theme.backgroundColor};
     border-radius: 50%;
+
+    ${skeletonBreathingCSS}
 `
 
 const InfoContainer = styled.div`
@@ -308,10 +302,10 @@ const Username = styled.div<{ $skeleton?: boolean }>`
     ${(props) =>
         props.$skeleton &&
         css`
-            background-color: ${props.theme.backgroundColor};
             width: 100%;
             height: 1.2em;
             border-radius: 0.3em;
+            ${skeletonBreathingCSS}
         `}
 `
 
@@ -370,9 +364,9 @@ const StatusCount = styled.div<{ $skeleton?: boolean }>`
     ${(p) =>
         p.$skeleton &&
         css`
-            background-color: ${p.theme.backgroundColor};
             width: 1em;
             height: 1.2em;
             border-radius: 0.3em;
+            ${skeletonBreathingCSS}
         `}
 `


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="420" height="591" alt="Screenshot 2025-10-11 at 21 17 43" src="https://github.com/user-attachments/assets/5c689f82-ba2a-4e03-8c96-9d57b665dc30" /> | <img width="420" height="591" alt="Screenshot 2025-10-11 at 21 17 08" src="https://github.com/user-attachments/assets/1e4580be-03fa-4bdf-ae19-9ce0427a65a0" /> |

`StatBoxSkeleton` 컴포넌트의 색상을 어색함이 없도록 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - 로딩 상태 스켈레톤을 배경색 기반에서 일관된 호흡 애니메이션으로 통일하여 시각적 일관성과 부드러움을 개선했습니다.
  - 프로필 이미지, 사용자명, 상태 카운트 등 로딩 스켈레톤이 더 자연스럽게 표시됩니다.
  - 기능 동작은 동일하며, 로딩 중 표시만 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->