### PR TITLE
모달 css를 useModal.css로 분리 & 모달 간 간격 문제 해결

### DIFF
--- a/frontend/public/global.css
+++ b/frontend/public/global.css
@@ -75,42 +75,6 @@ html {
     -moz-osx-font-smoothing: grayscale;
 }
 
-#window-container {
-    position: fixed;
-    top: 0;
-    left: 0;
-
-    width: 100dvw;
-    height: 100dvh;
-    box-sizing: border-box;
-
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    gap: 1em;
-    padding: 0.5em;
-
-    z-index: 99;
-    background-color: transparent;
-    pointer-events: none;
-}
-
-@keyframes window-container-background-dim {
-    0% {
-        background-color: transparent;
-    }
-    100% {
-        background-color: rgba(0, 0, 0, 0.3);
-    }
-}
-
-#window-container:has(div) {
-    pointer-events: initial;
-    background-color: rgba(0, 0, 0, 0.3);
-    animation: 0.5s var(--cubic) window-container-background-dim;
-}
-
 #confirmation {
     position: fixed;
     top: 0;
@@ -214,10 +178,6 @@ body {
 @media screen and (max-width: 500px) {
     body {
         -webkit-text-size-adjust: 100%;
-    }
-
-    #modal:has(div) {
-        padding: 0;
     }
 
     .Toastify__toast {

--- a/frontend/src/utils/useModal.css
+++ b/frontend/src/utils/useModal.css
@@ -1,0 +1,36 @@
+#window-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+
+    width: 100dvw;
+    height: 100dvh;
+    box-sizing: border-box;
+
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    align-content: center;
+    gap: 1em;
+    padding: 0.5em;
+
+    z-index: 99;
+    background-color: transparent;
+    pointer-events: none;
+}
+
+@keyframes window-container-background-dim {
+    0% {
+        background-color: transparent;
+    }
+    100% {
+        background-color: rgba(0, 0, 0, 0.3);
+    }
+}
+
+#window-container:has(div) {
+    pointer-events: initial;
+    background-color: rgba(0, 0, 0, 0.3);
+    animation: 0.5s var(--cubic) window-container-background-dim;
+}

--- a/frontend/src/utils/useModal.tsx
+++ b/frontend/src/utils/useModal.tsx
@@ -11,6 +11,8 @@ import {
 
 import styled, { css } from "styled-components"
 
+import "./useModal.css"
+
 import useStopVerticalScroll from "@utils/useStopVerticalScroll"
 
 import { scaleDown, scaleUp } from "@assets/keyframes"


### PR DESCRIPTION
- CSS 코드의 적절한 분리를 위해 `global.css`의 모달 css 코드를 `useModal.css`로 분리했습니다.
  - 빌드에 css가 포함되어 버전 관리가 올바르게 이뤄집니다. (추가되는 오버헤드 x)
- 모달이 두 개 이상 띄워질 경우 간격이 너무 넓던 문제를 해결했습니다.

| Before | After |
|---|---|
| <img width="830" height="1342" alt="Screenshot 2025-10-17 at 21 17 00" src="https://github.com/user-attachments/assets/b57bb9d0-7271-4ce0-a68c-60fc840a7cfa" /> | <img width="830" height="1342" alt="Screenshot 2025-10-17 at 21 16 48" src="https://github.com/user-attachments/assets/6ee24335-e828-4b46-a0b5-020f800d49a6" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩터**
  * 모달 스타일링을 전역 스타일시트에서 전용 모듈로 이동하여 코드 조직을 개선했습니다.
  * 모달 백드롭 및 애니메이션 효과의 관리를 통합한 별도 모듈로 재구성했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->