### PR TITLE
StatBoxSkeleton에서 아이콘도 도형으로 변경

### DIFF
--- a/frontend/src/components/social/StatContainer.tsx
+++ b/frontend/src/components/social/StatContainer.tsx
@@ -127,15 +127,11 @@ export function StatBoxSkeleton({ mine }: { mine?: boolean }) {
                 <Username $skeleton />
                 <SimpleStats>
                     <StatsUnit key="task">
-                        <StatusIconWrapper $type="task">
-                            <FeatherIcon icon="check" />
-                        </StatusIconWrapper>
+                        <SkeletonStatusIconWrapper />
                         <StatusCount $skeleton />
                     </StatsUnit>
                     <StatsUnit key="reaction">
-                        <StatusIconWrapper $type="reaction">
-                            <FeatherIcon icon="heart" />
-                        </StatusIconWrapper>
+                        <SkeletonStatusIconWrapper />
                         <StatusCount $skeleton />
                     </StatsUnit>
                 </SimpleStats>
@@ -303,7 +299,7 @@ const Username = styled.div<{ $skeleton?: boolean }>`
         props.$skeleton &&
         css`
             width: 100%;
-            height: 1.2em;
+            height: 1.15em;
             border-radius: 0.3em;
             ${skeletonBreathingCSS}
         `}
@@ -355,6 +351,21 @@ const StatusIconWrapper = styled.div<{ $type: "task" | "reaction" }>`
                 fill: ${(p) => p.theme.textColor};
             `}
     }
+`
+
+const SkeletonStatusIconWrapper = styled.div`
+    box-sizing: border-box;
+    aspect-ratio: 1;
+    height: 18px;
+    padding: 0;
+
+    border-radius: 50%;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    ${skeletonBreathingCSS}
 `
 
 const StatusCount = styled.div<{ $skeleton?: boolean }>`


### PR DESCRIPTION
| Before | After |
|---|---|
| <img width="418" height="414" alt="Screenshot 2025-10-29 at 22 32 27" src="https://github.com/user-attachments/assets/4471ed98-7f25-4691-b9f8-8aff6c5b234f" /> | <img width="418" height="414" alt="Screenshot 2025-10-29 at 22 32 12" src="https://github.com/user-attachments/assets/40f63054-d914-4bad-98dc-4f8664e58e90" /> |

`StatBox` 로딩 중에 아이콘도 스켈레톤 스타일을 따르도록 변경했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 소셜 기능의 로딩 상태(스켈레톤) UI 개선 및 최적화
  * 작업 및 반응 아이콘의 로딩 애니메이션 업데이트
  * 사용자명 스켈레톤 높이 세부 조정으로 시각적 일관성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->